### PR TITLE
feat: Add feature flags and licensing module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
 .prclean-summary.txt
+claude-progress.md
 
 # IDEs
 .vscode/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,26 +18,6 @@ swift-format lint --recursive Sources/ Tests/
 swiftlint lint
 ```
 
-## Key File Paths
-
-| Area | Path |
-|------|------|
-| Panel protocol | `Sources/DevToolsKit/Core/DevToolPanel.swift` |
-| Central manager | `Sources/DevToolsKit/Core/DevToolsManager.swift` |
-| Config enums | `Sources/DevToolsKit/Core/DevToolsConfiguration.swift` |
-| Log provider protocol | `Sources/DevToolsKit/Core/DiagnosticLogProvider.swift` |
-| Developer menu | `Sources/DevToolsKit/Menu/DevToolsCommands.swift` |
-| Dock modifier | `Sources/DevToolsKit/Modifiers/DevToolsDockModifier.swift` |
-| Window managers | `Sources/DevToolsKit/Window/` |
-| Performance panel | `Sources/DevToolsKit/Panels/PerformancePanel/` |
-| Environment panel | `Sources/DevToolsKit/Panels/EnvironmentPanel/` |
-| Data inspector | `Sources/DevToolsKit/Panels/DataInspectorPanel/` |
-| Diagnostic export | `Sources/DevToolsKit/Export/` |
-| Log store & handler | `Sources/DevToolsKitLogging/` |
-| Log panel | `Sources/DevToolsKitLogging/LogPanel.swift` |
-| Core tests | `Tests/DevToolsKitTests/` |
-| Logging tests | `Tests/DevToolsKitLoggingTests/` |
-
 ## Architecture
 
 - `DevToolsManager` (@Observable, @MainActor) is the central registry
@@ -74,7 +54,30 @@ swiftlint lint
 
 ## Workflow
 
-GitHub Flow: Issue → branch `<type>/<issue>-<slug>` → commits → PR → merge to `main`.
+## Workflow Rules
+
+- Always read this CLAUDE.md before making significant changes.
+- Before starting work, propose a concrete plan and ask for approval.
+- Keep a running log in `claude-progress.md`:
+  - What was planned.
+  - What was completed.
+  - Design decisions and trade-offs made.
+- Do not change without explicit approval:
+  - Bundle identifier.
+  - Entitlements (especially app sandbox setting).
+  - Signing configuration.
+  - Deployment targets.
+- Follow a "GitHub Flow"
+  - Work must be associated with a GitHub Issue. If one doesn't exist, create one.
+  - Create a feature branch before any implementation: `<type>/<issue-number>-<slug>`.
+  - Commit and push work to feature branch at each major phase of the plan
+  - Update PROGRESS.md if present and applicable when starting and after completing each phase
+  - Create a PR to merge into "main" when the plan is completed and wait for user input
+  - After the PR is approved perform "clean up" to prepare for new work:
+    - squash-merge the PR main
+    - delete feature branch (remote & local)
+    - checkout and pull main
+
 
 ## Style
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,24 @@
 {
-  "originHash" : "003287786684b50845198c00ad6c088b4ce0813a78bb352dcfa6fbef543c79a5",
+  "originHash" : "539135daab584fdde8903915a2753b4405759beca63db4f432910da0959280a5",
   "pins" : [
+    {
+      "identity" : "licenseseat-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/licenseseat/licenseseat-swift.git",
+      "state" : {
+        "revision" : "6149935016228b70631d805cb512e11c4cf335ad",
+        "version" : "0.4.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "60f13f60c4d093691934dc6cfdf5f508ada1f894",
+        "version" : "2.6.0"
+      }
+    },
     {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
@@ -8,6 +26,15 @@
       "state" : {
         "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
         "version" : "1.10.1"
+      }
+    },
+    {
+      "identity" : "swift-metrics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-metrics.git",
+      "state" : {
+        "revision" : "f17c111cec972c2a4922cef38cf64f76f7e87886",
+        "version" : "2.8.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -16,9 +16,23 @@ let package = Package(
             name: "DevToolsKitLogging",
             targets: ["DevToolsKitLogging"]
         ),
+        .library(
+            name: "DevToolsKitLicensing",
+            targets: ["DevToolsKitLicensing"]
+        ),
+        .library(
+            name: "DevToolsKitLicensingSeat",
+            targets: ["DevToolsKitLicensingSeat"]
+        ),
+        .library(
+            name: "DevToolsKitLicensingStoreKit",
+            targets: ["DevToolsKitLicensingStoreKit"]
+        ),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.0")
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.0"),
+        .package(url: "https://github.com/apple/swift-metrics.git", from: "2.5.0"),
+        .package(url: "https://github.com/licenseseat/licenseseat-swift.git", from: "0.3.1"),
     ],
     targets: [
         .target(
@@ -37,6 +51,35 @@ let package = Package(
                 .swiftLanguageMode(.v6)
             ]
         ),
+        .target(
+            name: "DevToolsKitLicensing",
+            dependencies: [
+                "DevToolsKit",
+                .product(name: "Metrics", package: "swift-metrics"),
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        ),
+        .target(
+            name: "DevToolsKitLicensingSeat",
+            dependencies: [
+                "DevToolsKitLicensing",
+                .product(name: "LicenseSeat", package: "licenseseat-swift"),
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        ),
+        .target(
+            name: "DevToolsKitLicensingStoreKit",
+            dependencies: [
+                "DevToolsKitLicensing",
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        ),
         .testTarget(
             name: "DevToolsKitTests",
             dependencies: ["DevToolsKit"],
@@ -47,6 +90,13 @@ let package = Package(
         .testTarget(
             name: "DevToolsKitLoggingTests",
             dependencies: ["DevToolsKitLogging"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        ),
+        .testTarget(
+            name: "DevToolsKitLicensingTests",
+            dependencies: ["DevToolsKitLicensing"],
             swiftSettings: [
                 .swiftLanguageMode(.v6)
             ]

--- a/Sources/DevToolsKit/Core/DistributionChannel.swift
+++ b/Sources/DevToolsKit/Core/DistributionChannel.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Distribution channel for the app, used by DevToolsKit modules to vary behavior.
+///
+/// Modules that differ by distribution channel split into separate SPM targets.
+/// For example, `DevToolsKitLicensingSeat` is used for website distribution and
+/// `DevToolsKitLicensingStoreKit` for App Store distribution. The integrating app
+/// imports only the target appropriate for its channel.
+///
+/// **Build flag convention:** Set `APPSTORE_BUILD` in the app target's Swift compiler
+/// flags for App Store builds. Modules may check this at compile time via
+/// `#if APPSTORE_BUILD`.
+public enum DistributionChannel: String, Sendable, CaseIterable, Codable {
+    /// Direct distribution: LemonSqueezy/LicenseSeat licensing, Sparkle updates.
+    case website
+
+    /// Mac App Store: StoreKit IAP, system auto-update.
+    case appStore
+}

--- a/Sources/DevToolsKitLicensing/Analytics/FlagMetrics.swift
+++ b/Sources/DevToolsKitLicensing/Analytics/FlagMetrics.swift
@@ -1,0 +1,44 @@
+import CoreMetrics
+
+/// Emits feature flag events through the swift-metrics API.
+///
+/// Events are recorded as counters. A future `DevToolsKitMetrics` module can register
+/// a `MetricsFactory` backend to collect them, mirroring how `DevToolsKitLogging`
+/// registers a `LogHandler` for swift-log.
+public enum FlagMetrics {
+    /// Record a flag check event.
+    ///
+    /// - Parameters:
+    ///   - flagID: The feature flag's stable identifier.
+    ///   - result: Whether the flag resolved to enabled.
+    public static func recordCheck(flagID: String, result: Bool) {
+        Counter(
+            label: "devtools.feature_flag.check",
+            dimensions: [("flag_id", flagID), ("result", "\(result)")]
+        ).increment()
+    }
+
+    /// Record a cohort assignment event.
+    ///
+    /// - Parameters:
+    ///   - flagID: The feature flag's stable identifier.
+    ///   - cohort: The assigned cohort name.
+    public static func recordCohortAssignment(flagID: String, cohort: String) {
+        Counter(
+            label: "devtools.feature_flag.cohort_assignment",
+            dimensions: [("flag_id", flagID), ("cohort", cohort)]
+        ).increment()
+    }
+
+    /// Record an override event.
+    ///
+    /// - Parameters:
+    ///   - flagID: The feature flag's stable identifier.
+    ///   - value: The override value.
+    public static func recordOverride(flagID: String, value: Bool) {
+        Counter(
+            label: "devtools.feature_flag.override",
+            dimensions: [("flag_id", flagID), ("value", "\(value)")]
+        ).increment()
+    }
+}

--- a/Sources/DevToolsKitLicensing/Core/DevToolsLicenseStatus.swift
+++ b/Sources/DevToolsKitLicensing/Core/DevToolsLicenseStatus.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Current status of the license as reported by the active backend.
+public enum DevToolsLicenseStatus: String, Sendable, Codable {
+    /// No backend configured or no license action taken yet.
+    case unconfigured
+
+    /// License is active and validated (online).
+    case active
+
+    /// License is valid via offline token (no server contact).
+    case offlineValid
+
+    /// License was previously active but is now inactive (e.g., expired subscription).
+    case inactive
+
+    /// License key or token is invalid.
+    case invalid
+
+    /// Validation is in progress.
+    case pending
+}

--- a/Sources/DevToolsKitLicensing/Core/FeatureFlagDefinition.swift
+++ b/Sources/DevToolsKitLicensing/Core/FeatureFlagDefinition.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// Defines a feature flag with its metadata, default value, license gating, and experiment config.
+///
+/// Create definitions at app startup and register them with ``LicensingManager/registerFlags(_:)``.
+///
+/// ```swift
+/// let flag = FeatureFlagDefinition(
+///     id: "myapp.new-feature",
+///     name: "New Feature",
+///     description: "Enables the new feature",
+///     category: "Experimental",
+///     defaultEnabled: false,
+///     requiredTier: .premium
+/// )
+/// ```
+public struct FeatureFlagDefinition: Sendable, Hashable, Identifiable {
+    /// Stable identifier in reverse-domain style (e.g., `"myapp.new-feature"`).
+    public let id: String
+
+    /// Human-readable name shown in the Feature Flags panel.
+    public let name: String
+
+    /// Description of what this flag controls.
+    public let description: String
+
+    /// Category for grouping in the panel UI (e.g., `"Debug"`, `"Experimental"`).
+    public let category: String
+
+    /// Default value when no override, rollout, or experiment applies.
+    public let defaultEnabled: Bool
+
+    /// Minimum license tier required for this flag to be enabled.
+    public let requiredTier: LicenseTier
+
+    /// Optional percentage rollout configuration.
+    public let rollout: RolloutDefinition?
+
+    /// Optional multi-cohort experiment configuration.
+    public let experiment: CohortDefinition?
+
+    /// - Parameters:
+    ///   - id: Stable identifier in reverse-domain style.
+    ///   - name: Human-readable name.
+    ///   - description: Description of the flag's purpose.
+    ///   - category: Category for panel grouping.
+    ///   - defaultEnabled: Default value; defaults to `false`.
+    ///   - requiredTier: License tier required; defaults to `.free`.
+    ///   - rollout: Optional rollout config for gradual enablement.
+    ///   - experiment: Optional cohort experiment config.
+    public init(
+        id: String,
+        name: String,
+        description: String,
+        category: String,
+        defaultEnabled: Bool = false,
+        requiredTier: LicenseTier = .free,
+        rollout: RolloutDefinition? = nil,
+        experiment: CohortDefinition? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.category = category
+        self.defaultEnabled = defaultEnabled
+        self.requiredTier = requiredTier
+        self.rollout = rollout
+        self.experiment = experiment
+    }
+}

--- a/Sources/DevToolsKitLicensing/Core/FeatureFlagState.swift
+++ b/Sources/DevToolsKitLicensing/Core/FeatureFlagState.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Runtime state of a feature flag, including override and experiment information.
+///
+/// Obtain via ``LicensingManager/flagState(for:)``.
+public struct FeatureFlagState: Sendable {
+    /// The flag definition this state corresponds to.
+    public let definition: FeatureFlagDefinition
+
+    /// Whether the flag is currently enabled (after all resolution logic).
+    public let isEnabled: Bool
+
+    /// Whether a developer override is active for this flag.
+    public let isOverridden: Bool
+
+    /// Whether this flag is gated by a license tier the user does not have.
+    public let isGated: Bool
+
+    /// Assigned cohort name if the flag has an experiment; `nil` otherwise.
+    public let cohort: String?
+
+    /// When the active override expires, if a TTL was set; `nil` for permanent overrides.
+    public let overrideExpiresAt: Date?
+
+    /// - Parameters:
+    ///   - definition: The flag definition.
+    ///   - isEnabled: Resolved enabled state.
+    ///   - isOverridden: Whether an override is active.
+    ///   - isGated: Whether the flag is license-gated.
+    ///   - cohort: Assigned experiment cohort, if any.
+    ///   - overrideExpiresAt: Override expiry date, if timed.
+    public init(
+        definition: FeatureFlagDefinition,
+        isEnabled: Bool,
+        isOverridden: Bool,
+        isGated: Bool,
+        cohort: String?,
+        overrideExpiresAt: Date?
+    ) {
+        self.definition = definition
+        self.isEnabled = isEnabled
+        self.isOverridden = isOverridden
+        self.isGated = isGated
+        self.cohort = cohort
+        self.overrideExpiresAt = overrideExpiresAt
+    }
+}

--- a/Sources/DevToolsKitLicensing/Core/LicenseBackend.swift
+++ b/Sources/DevToolsKitLicensing/Core/LicenseBackend.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Credential used to activate a license.
+///
+/// The credential type depends on the distribution channel:
+/// - Website (LicenseSeat): use ``licenseKey(_:)`` for online or ``offlineToken(_:)`` for offline.
+/// - App Store (StoreKit): the backend handles purchases internally; no credential is needed.
+public enum LicenseCredential: Sendable {
+    /// A user-entered license key for online activation via LicenseSeat.
+    case licenseKey(String)
+
+    /// A pasted offline token for local-only validation via LicenseSeat.
+    case offlineToken(String)
+}
+
+/// Protocol for license validation backends.
+///
+/// `LicensingManager` delegates all license operations to a conforming backend.
+/// Two built-in backends are provided:
+/// - `LicenseSeatBackend` (in `DevToolsKitLicensingSeat`) for website distribution
+/// - `StoreKitBackend` (in `DevToolsKitLicensingStoreKit`) for App Store distribution
+@MainActor
+public protocol LicenseBackend: Sendable {
+    /// Current license status.
+    var status: DevToolsLicenseStatus { get }
+
+    /// Set of active entitlement names granted by the current license.
+    var activeEntitlements: Set<String> { get }
+
+    /// Activate the license with the given credential.
+    ///
+    /// - Parameter credential: The license key or offline token.
+    /// - Throws: If activation fails (network error, invalid key, etc.).
+    func activate(with credential: LicenseCredential) async throws
+
+    /// Re-validate the current license state.
+    ///
+    /// - Throws: If validation fails.
+    func validate() async throws
+
+    /// Deactivate the current license.
+    ///
+    /// - Throws: If deactivation fails.
+    func deactivate() async throws
+}

--- a/Sources/DevToolsKitLicensing/Core/LicenseTier.swift
+++ b/Sources/DevToolsKitLicensing/Core/LicenseTier.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// License tier required to access a feature flag.
+///
+/// Built-in tiers cover common free/premium splits. Use ``custom(_:)`` for
+/// entitlement-based gating that maps to LicenseSeat entitlements or StoreKit product IDs.
+public enum LicenseTier: Sendable, Hashable, Codable {
+    /// Available to all users regardless of license status.
+    case free
+
+    /// Requires an active premium license or subscription.
+    case premium
+
+    /// Requires a specific named entitlement from the license backend.
+    ///
+    /// The string maps to a LicenseSeat entitlement name or a StoreKit product
+    /// mapping defined at backend initialization.
+    case custom(String)
+}

--- a/Sources/DevToolsKitLicensing/Core/LicensingManager.swift
+++ b/Sources/DevToolsKitLicensing/Core/LicensingManager.swift
@@ -1,0 +1,451 @@
+import DevToolsKit
+import Foundation
+import Observation
+
+/// Central manager for feature flags, license gating, and experimentation.
+///
+/// Create an instance with a key prefix and a license backend, register your flag
+/// definitions, then query flag state throughout your app.
+///
+/// ```swift
+/// let licensing = LicensingManager(keyPrefix: "myapp", backend: myBackend)
+/// licensing.registerFlags([debugOverlay, newExporter])
+///
+/// if licensing.isEnabled("myapp.new-exporter") { ... }
+/// ```
+@MainActor
+@Observable
+public final class LicensingManager: Sendable {
+    // MARK: - Configuration
+
+    /// Prefix for all UserDefaults keys.
+    public let keyPrefix: String
+
+    /// The license validation backend.
+    public let backend: any LicenseBackend
+
+    // MARK: - Registered Flags
+
+    /// All registered flag definitions keyed by ID.
+    public private(set) var flagDefinitions: [String: FeatureFlagDefinition] = [:]
+
+    /// Ordered list of flag IDs in registration order.
+    public private(set) var flagOrder: [String] = []
+
+    // MARK: - Enrollment
+
+    /// Enrollment ID manager for deterministic cohort/rollout assignment.
+    public let enrollment: EnrollmentID
+
+    // MARK: - State Change Observation
+
+    /// Monotonically increasing version counter, incremented on any state change.
+    public private(set) var stateVersion: UInt64 = 0
+
+    // MARK: - Init
+
+    /// Create a licensing manager.
+    ///
+    /// - Parameters:
+    ///   - keyPrefix: Prefix for all persisted keys (e.g., `"myapp"`).
+    ///   - backend: The license validation backend.
+    ///   - regenerationInterval: Enrollment ID regeneration interval; defaults to 90 days.
+    public init(
+        keyPrefix: String,
+        backend: any LicenseBackend,
+        regenerationInterval: TimeInterval = 90 * 24 * 60 * 60
+    ) {
+        self.keyPrefix = keyPrefix
+        self.backend = backend
+        self.enrollment = EnrollmentID(
+            keyPrefix: keyPrefix, regenerationInterval: regenerationInterval)
+    }
+
+    // MARK: - Flag Registration
+
+    /// Register a collection of feature flag definitions.
+    ///
+    /// Duplicate IDs are silently ignored; the first registration wins.
+    ///
+    /// - Parameter flags: The flag definitions to register.
+    public func registerFlags(_ flags: [FeatureFlagDefinition]) {
+        for flag in flags {
+            guard flagDefinitions[flag.id] == nil else { continue }
+            flagDefinitions[flag.id] = flag
+            flagOrder.append(flag.id)
+        }
+    }
+
+    /// Register a single feature flag definition.
+    ///
+    /// - Parameter flag: The flag definition to register.
+    public func registerFlag(_ flag: FeatureFlagDefinition) {
+        registerFlags([flag])
+    }
+
+    // MARK: - Flag Resolution
+
+    /// Check whether a feature flag is enabled.
+    ///
+    /// Resolution order:
+    /// 1. Active (non-expired) developer override → use override value
+    /// 2. License tier gating → if user lacks required tier, flag is disabled
+    /// 3. Experiment cohort → first cohort name is treated as enabled
+    /// 4. Percentage rollout → bucket < percentage means enabled
+    /// 5. Default value from definition
+    ///
+    /// - Parameter flagID: The flag's stable identifier.
+    /// - Returns: `true` if enabled, `false` if disabled or unregistered.
+    public func isEnabled(_ flagID: String) -> Bool {
+        let state = flagState(for: flagID)
+        FlagMetrics.recordCheck(flagID: flagID, result: state?.isEnabled ?? false)
+        return state?.isEnabled ?? false
+    }
+
+    /// Get the full resolved state of a feature flag.
+    ///
+    /// - Parameter flagID: The flag's stable identifier.
+    /// - Returns: The resolved state, or `nil` if the flag is not registered.
+    public func flagState(for flagID: String) -> FeatureFlagState? {
+        guard let definition = flagDefinitions[flagID] else { return nil }
+        return resolveState(for: definition)
+    }
+
+    /// All resolved flag states in registration order.
+    public var allFlagStates: [FeatureFlagState] {
+        flagOrder.compactMap { flagState(for: $0) }
+    }
+
+    // MARK: - Entitlements
+
+    /// Check whether a named entitlement is active.
+    ///
+    /// Delegates to the backend's ``LicenseBackend/activeEntitlements``.
+    ///
+    /// - Parameter name: The entitlement name to check.
+    /// - Returns: `true` if the backend grants this entitlement.
+    public func hasEntitlement(_ name: String) -> Bool {
+        backend.activeEntitlements.contains(name)
+    }
+
+    // MARK: - Developer Overrides
+
+    /// Set a developer override for a flag.
+    ///
+    /// - Parameters:
+    ///   - enabled: The override value.
+    ///   - flagID: The flag's stable identifier.
+    ///   - ttl: Optional time-to-live; the override expires after this duration.
+    public func setOverride(_ enabled: Bool, for flagID: String, expiresAfter ttl: Duration? = nil) {
+        UserDefaults.standard.set(enabled, forKey: overrideKey(flagID))
+        UserDefaults.standard.set(true, forKey: overrideExistsKey(flagID))
+
+        if let ttl {
+            let expiresAt = Date().addingTimeInterval(Double(ttl.components.seconds))
+            UserDefaults.standard.set(
+                expiresAt.timeIntervalSince1970, forKey: overrideExpiryKey(flagID))
+        } else {
+            UserDefaults.standard.removeObject(forKey: overrideExpiryKey(flagID))
+        }
+
+        FlagMetrics.recordOverride(flagID: flagID, value: enabled)
+        incrementStateVersion()
+    }
+
+    /// Clear the developer override for a flag.
+    ///
+    /// - Parameter flagID: The flag's stable identifier.
+    public func clearOverride(for flagID: String) {
+        UserDefaults.standard.removeObject(forKey: overrideKey(flagID))
+        UserDefaults.standard.removeObject(forKey: overrideExistsKey(flagID))
+        UserDefaults.standard.removeObject(forKey: overrideExpiryKey(flagID))
+        incrementStateVersion()
+    }
+
+    /// Clear all developer overrides for all registered flags.
+    public func clearAllOverrides() {
+        for flagID in flagOrder {
+            UserDefaults.standard.removeObject(forKey: overrideKey(flagID))
+            UserDefaults.standard.removeObject(forKey: overrideExistsKey(flagID))
+            UserDefaults.standard.removeObject(forKey: overrideExpiryKey(flagID))
+        }
+        incrementStateVersion()
+    }
+
+    // MARK: - Enrollment ID Convenience
+
+    /// The current enrollment ID value.
+    public var enrollmentID: UUID { enrollment.value }
+
+    /// When the current enrollment ID will automatically regenerate.
+    public var enrollmentIDExpiresAt: Date { enrollment.expiresAt }
+
+    /// Manually reset the enrollment ID.
+    public func resetEnrollmentID() {
+        enrollment.reset()
+        incrementStateVersion()
+    }
+
+    // MARK: - License Actions
+
+    /// Activate the license with the given credential, delegating to the backend.
+    ///
+    /// - Parameter credential: The license key or offline token.
+    public func activate(with credential: LicenseCredential) async throws {
+        try await backend.activate(with: credential)
+        incrementStateVersion()
+    }
+
+    /// Re-validate the current license.
+    public func validate() async throws {
+        try await backend.validate()
+        incrementStateVersion()
+    }
+
+    /// Deactivate the current license.
+    public func deactivate() async throws {
+        try await backend.deactivate()
+        incrementStateVersion()
+    }
+
+    /// Current license status from the backend.
+    public var licenseStatus: DevToolsLicenseStatus {
+        backend.status
+    }
+
+    // MARK: - Async Observation
+
+    /// An async stream that yields the flag state whenever it changes.
+    ///
+    /// - Parameter flagID: The flag to observe.
+    /// - Returns: An async stream of state snapshots.
+    public func stateChanges(for flagID: String) -> AsyncStream<FeatureFlagState> {
+        AsyncStream { continuation in
+            let task = Task { @MainActor [weak self] in
+                guard let self else {
+                    continuation.finish()
+                    return
+                }
+                var lastVersion: UInt64 = 0
+                while !Task.isCancelled {
+                    if self.stateVersion != lastVersion {
+                        lastVersion = self.stateVersion
+                        if let state = self.flagState(for: flagID) {
+                            continuation.yield(state)
+                        }
+                    }
+                    try? await Task.sleep(for: .milliseconds(100))
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+
+    // MARK: - Private Resolution
+
+    private func resolveState(for definition: FeatureFlagDefinition) -> FeatureFlagState {
+        let overrideInfo = activeOverride(for: definition.id)
+
+        // 1. Check override
+        if let override = overrideInfo {
+            return FeatureFlagState(
+                definition: definition,
+                isEnabled: override.value,
+                isOverridden: true,
+                isGated: false,
+                cohort: resolveCohort(for: definition),
+                overrideExpiresAt: override.expiresAt
+            )
+        }
+
+        // 2. Check license gating
+        let isGated = !isTierSatisfied(definition.requiredTier)
+
+        if isGated {
+            return FeatureFlagState(
+                definition: definition,
+                isEnabled: false,
+                isOverridden: false,
+                isGated: true,
+                cohort: nil,
+                overrideExpiresAt: nil
+            )
+        }
+
+        // 3. Check experiment
+        if let experiment = definition.experiment {
+            let eligible = experiment.targeting.allSatisfy { $0.isSatisfied() }
+            if eligible {
+                let cohort = CohortResolver.assignCohort(
+                    enrollmentID: enrollment.value,
+                    flagID: definition.id,
+                    cohorts: experiment.cohorts
+                )
+                if let cohort {
+                    FlagMetrics.recordCohortAssignment(flagID: definition.id, cohort: cohort)
+                }
+                // First cohort is treated as "control" (enabled), all others also enabled
+                // since being in a cohort means participating
+                let enabled = cohort != nil
+                return FeatureFlagState(
+                    definition: definition,
+                    isEnabled: enabled,
+                    isOverridden: false,
+                    isGated: false,
+                    cohort: cohort,
+                    overrideExpiresAt: nil
+                )
+            }
+        }
+
+        // 4. Check rollout
+        if let rollout = definition.rollout {
+            let eligible = rollout.targeting.allSatisfy { $0.isSatisfied() }
+            if eligible {
+                let inRollout = CohortResolver.isInRollout(
+                    enrollmentID: enrollment.value,
+                    flagID: definition.id,
+                    percentage: rollout.percentage
+                )
+                return FeatureFlagState(
+                    definition: definition,
+                    isEnabled: inRollout,
+                    isOverridden: false,
+                    isGated: false,
+                    cohort: nil,
+                    overrideExpiresAt: nil
+                )
+            }
+        }
+
+        // 5. Default
+        return FeatureFlagState(
+            definition: definition,
+            isEnabled: definition.defaultEnabled,
+            isOverridden: false,
+            isGated: false,
+            cohort: nil,
+            overrideExpiresAt: nil
+        )
+    }
+
+    private func isTierSatisfied(_ tier: LicenseTier) -> Bool {
+        switch tier {
+        case .free:
+            return true
+        case .premium:
+            let status = backend.status
+            return status == .active || status == .offlineValid
+        case .custom(let entitlement):
+            return hasEntitlement(entitlement)
+        }
+    }
+
+    private func resolveCohort(for definition: FeatureFlagDefinition) -> String? {
+        guard let experiment = definition.experiment else { return nil }
+        return CohortResolver.assignCohort(
+            enrollmentID: enrollment.value,
+            flagID: definition.id,
+            cohorts: experiment.cohorts
+        )
+    }
+
+    private struct OverrideInfo {
+        let value: Bool
+        let expiresAt: Date?
+    }
+
+    private func activeOverride(for flagID: String) -> OverrideInfo? {
+        guard UserDefaults.standard.bool(forKey: overrideExistsKey(flagID)) else {
+            return nil
+        }
+
+        // Check expiry
+        let expiryInterval = UserDefaults.standard.double(forKey: overrideExpiryKey(flagID))
+        if expiryInterval > 0 {
+            let expiresAt = Date(timeIntervalSince1970: expiryInterval)
+            if Date() >= expiresAt {
+                // Expired — clear it
+                clearOverride(for: flagID)
+                return nil
+            }
+            let value = UserDefaults.standard.bool(forKey: overrideKey(flagID))
+            return OverrideInfo(value: value, expiresAt: expiresAt)
+        }
+
+        let value = UserDefaults.standard.bool(forKey: overrideKey(flagID))
+        return OverrideInfo(value: value, expiresAt: nil)
+    }
+
+    // MARK: - Key Helpers
+
+    private func key(_ suffix: String) -> String {
+        "\(keyPrefix).\(suffix)"
+    }
+
+    private func overrideKey(_ flagID: String) -> String {
+        key("featureFlag.override.\(flagID)")
+    }
+
+    private func overrideExistsKey(_ flagID: String) -> String {
+        key("featureFlag.override.\(flagID).exists")
+    }
+
+    private func overrideExpiryKey(_ flagID: String) -> String {
+        key("featureFlag.override.\(flagID).expiresAt")
+    }
+
+    private func incrementStateVersion() {
+        stateVersion += 1
+    }
+}
+
+// MARK: - DiagnosticProvider
+
+extension LicensingManager: DiagnosticProvider {
+    public var sectionName: String { "licensing" }
+
+    public func collect() async -> any Codable & Sendable {
+        let flags = allFlagStates.map { state in
+            LicensingDiagnosticFlag(
+                id: state.definition.id,
+                isEnabled: state.isEnabled,
+                isOverridden: state.isOverridden,
+                isGated: state.isGated,
+                cohort: state.cohort
+            )
+        }
+        return LicensingDiagnosticData(
+            licenseStatus: licenseStatus.rawValue,
+            activeEntitlements: Array(backend.activeEntitlements).sorted(),
+            registeredFlagCount: flagDefinitions.count,
+            overriddenFlagCount: allFlagStates.filter(\.isOverridden).count,
+            flags: flags,
+            enrollmentIDGeneratedAt: enrollment.generatedAt,
+            enrollmentIDExpiresAt: enrollment.expiresAt
+        )
+    }
+}
+
+/// Diagnostic data structure for the licensing section of diagnostic exports.
+struct LicensingDiagnosticData: Codable, Sendable {
+    let licenseStatus: String
+    let activeEntitlements: [String]
+    let registeredFlagCount: Int
+    let overriddenFlagCount: Int
+    let flags: [LicensingDiagnosticFlag]
+    let enrollmentIDGeneratedAt: Date
+    let enrollmentIDExpiresAt: Date
+}
+
+/// Diagnostic snapshot of a single flag's state.
+struct LicensingDiagnosticFlag: Codable, Sendable {
+    let id: String
+    let isEnabled: Bool
+    let isOverridden: Bool
+    let isGated: Bool
+    let cohort: String?
+}

--- a/Sources/DevToolsKitLicensing/Core/ValidationMode.swift
+++ b/Sources/DevToolsKitLicensing/Core/ValidationMode.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// How the license backend validates credentials.
+///
+/// Only meaningful for backends that support both modes (e.g., LicenseSeat).
+/// StoreKit validation is always handled by the system.
+public enum ValidationMode: String, Sendable, CaseIterable, Codable {
+    /// Validate using a locally-provided offline token with no network contact.
+    case offline
+
+    /// Validate via the licensing server (requires network).
+    case online
+}

--- a/Sources/DevToolsKitLicensing/Experimentation/CohortDefinition.swift
+++ b/Sources/DevToolsKitLicensing/Experimentation/CohortDefinition.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// A single cohort within a multi-cohort experiment.
+///
+/// Weights are relative — they do not need to sum to 100. The ``CohortResolver``
+/// normalizes them into cumulative bucket ranges (0–99).
+public struct Cohort: Sendable, Hashable, Codable {
+    /// Display name for this cohort (e.g., `"control"`, `"variant-a"`).
+    public let name: String
+
+    /// Relative weight for bucket assignment.
+    public let weight: Int
+
+    /// - Parameters:
+    ///   - name: Cohort name used in flag state and analytics.
+    ///   - weight: Relative weight; higher values mean more users are assigned.
+    public init(name: String, weight: Int) {
+        self.name = name
+        self.weight = weight
+    }
+}
+
+/// Configuration for a multi-cohort experiment attached to a feature flag.
+///
+/// Users are deterministically assigned to a cohort based on their enrollment ID
+/// and the flag ID. Users who do not meet the targeting rules fall back to the
+/// flag's ``FeatureFlagDefinition/defaultEnabled`` value.
+public struct CohortDefinition: Sendable, Hashable, Codable {
+    /// The cohorts in this experiment.
+    public let cohorts: [Cohort]
+
+    /// Targeting rules that must all be satisfied for a user to be enrolled.
+    public let targeting: [TargetingRule]
+
+    /// - Parameters:
+    ///   - cohorts: The cohorts with their relative weights.
+    ///   - targeting: Rules that gate enrollment; defaults to no restrictions.
+    public init(cohorts: [Cohort], targeting: [TargetingRule] = []) {
+        self.cohorts = cohorts
+        self.targeting = targeting
+    }
+}

--- a/Sources/DevToolsKitLicensing/Experimentation/CohortResolver.swift
+++ b/Sources/DevToolsKitLicensing/Experimentation/CohortResolver.swift
@@ -1,0 +1,64 @@
+import CryptoKit
+import Foundation
+
+/// Deterministically assigns users to cohorts or rollout buckets.
+///
+/// Uses a stable hash of `enrollmentID + flagID` to produce a bucket (0–99).
+/// The same input always yields the same bucket, ensuring consistent assignment
+/// across app launches.
+public enum CohortResolver {
+    /// Compute a stable bucket (0–99) from an enrollment ID and flag ID.
+    ///
+    /// - Parameters:
+    ///   - enrollmentID: The user's enrollment UUID.
+    ///   - flagID: The feature flag's stable identifier.
+    /// - Returns: An integer in `0..<100`.
+    public static func bucket(enrollmentID: UUID, flagID: String) -> Int {
+        let input = "\(enrollmentID.uuidString):\(flagID)"
+        let digest = SHA256.hash(data: Data(input.utf8))
+        let firstFourBytes = digest.prefix(4)
+        let value = firstFourBytes.reduce(0) { ($0 << 8) | UInt32($1) }
+        return Int(value % 100)
+    }
+
+    /// Resolve which cohort a user belongs to in a multi-cohort experiment.
+    ///
+    /// - Parameters:
+    ///   - enrollmentID: The user's enrollment UUID.
+    ///   - flagID: The feature flag's stable identifier.
+    ///   - cohorts: The experiment's cohort definitions.
+    /// - Returns: The name of the assigned cohort, or `nil` if cohorts are empty.
+    public static func assignCohort(
+        enrollmentID: UUID, flagID: String, cohorts: [Cohort]
+    ) -> String? {
+        guard !cohorts.isEmpty else { return nil }
+        let totalWeight = cohorts.reduce(0) { $0 + $1.weight }
+        guard totalWeight > 0 else { return cohorts.first?.name }
+
+        let userBucket = bucket(enrollmentID: enrollmentID, flagID: flagID)
+        let scaledBucket = userBucket * totalWeight / 100
+
+        var cumulative = 0
+        for cohort in cohorts {
+            cumulative += cohort.weight
+            if scaledBucket < cumulative {
+                return cohort.name
+            }
+        }
+        return cohorts.last?.name
+    }
+
+    /// Determine whether a user is within a percentage rollout.
+    ///
+    /// - Parameters:
+    ///   - enrollmentID: The user's enrollment UUID.
+    ///   - flagID: The feature flag's stable identifier.
+    ///   - percentage: The rollout percentage (0–100).
+    /// - Returns: `true` if the user's bucket is below the percentage threshold.
+    public static func isInRollout(
+        enrollmentID: UUID, flagID: String, percentage: Int
+    ) -> Bool {
+        let userBucket = bucket(enrollmentID: enrollmentID, flagID: flagID)
+        return userBucket < percentage
+    }
+}

--- a/Sources/DevToolsKitLicensing/Experimentation/EnrollmentID.swift
+++ b/Sources/DevToolsKitLicensing/Experimentation/EnrollmentID.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Manages a stable enrollment identifier used for deterministic cohort and rollout assignment.
+///
+/// The enrollment ID is a random UUID persisted to UserDefaults. It regenerates
+/// automatically after a configurable interval (default: 90 days) and can be
+/// manually reset via ``reset()``.
+@MainActor
+public final class EnrollmentID: Sendable {
+    private let idKey: String
+    private let generatedAtKey: String
+    private let regenerationInterval: TimeInterval
+
+    /// Current enrollment ID. Generated on first access if not present.
+    public var value: UUID {
+        if let stored = UserDefaults.standard.string(forKey: idKey),
+            let uuid = UUID(uuidString: stored),
+            !isExpired
+        {
+            return uuid
+        }
+        return regenerate()
+    }
+
+    /// When the current enrollment ID was generated.
+    public var generatedAt: Date {
+        let interval = UserDefaults.standard.double(forKey: generatedAtKey)
+        guard interval > 0 else { return Date() }
+        return Date(timeIntervalSince1970: interval)
+    }
+
+    /// When the current enrollment ID will automatically regenerate.
+    public var expiresAt: Date {
+        generatedAt.addingTimeInterval(regenerationInterval)
+    }
+
+    /// Whether the current enrollment ID has expired and needs regeneration.
+    private var isExpired: Bool {
+        let interval = UserDefaults.standard.double(forKey: generatedAtKey)
+        guard interval > 0 else { return true }
+        let generated = Date(timeIntervalSince1970: interval)
+        return Date().timeIntervalSince(generated) >= regenerationInterval
+    }
+
+    /// - Parameters:
+    ///   - keyPrefix: UserDefaults key prefix (e.g., `"myapp"`).
+    ///   - regenerationInterval: Seconds before automatic regeneration; defaults to 90 days.
+    public init(keyPrefix: String, regenerationInterval: TimeInterval = 90 * 24 * 60 * 60) {
+        self.idKey = "\(keyPrefix).enrollment.id"
+        self.generatedAtKey = "\(keyPrefix).enrollment.generatedAt"
+        self.regenerationInterval = regenerationInterval
+    }
+
+    /// Manually reset the enrollment ID, generating a new one immediately.
+    ///
+    /// - Returns: The new enrollment ID.
+    @discardableResult
+    public func reset() -> UUID {
+        regenerate()
+    }
+
+    @discardableResult
+    private func regenerate() -> UUID {
+        let newID = UUID()
+        UserDefaults.standard.set(newID.uuidString, forKey: idKey)
+        UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: generatedAtKey)
+        return newID
+    }
+}

--- a/Sources/DevToolsKitLicensing/Experimentation/RolloutDefinition.swift
+++ b/Sources/DevToolsKitLicensing/Experimentation/RolloutDefinition.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Configuration for a percentage-based gradual rollout of a feature flag.
+///
+/// Users are deterministically bucketed (0–99) based on their enrollment ID
+/// and the flag ID. If `bucket < percentage`, the flag is enabled.
+/// Users who do not meet the targeting rules fall back to the flag's
+/// ``FeatureFlagDefinition/defaultEnabled`` value.
+public struct RolloutDefinition: Sendable, Hashable, Codable {
+    /// Percentage of eligible users who should have this flag enabled (0–100).
+    public let percentage: Int
+
+    /// Targeting rules that must all be satisfied for a user to be in the rollout.
+    public let targeting: [TargetingRule]
+
+    /// - Parameters:
+    ///   - percentage: Percentage of eligible users (0–100) to enable the flag for.
+    ///   - targeting: Rules that gate eligibility; defaults to no restrictions.
+    public init(percentage: Int, targeting: [TargetingRule] = []) {
+        self.percentage = min(max(percentage, 0), 100)
+        self.targeting = targeting
+    }
+}

--- a/Sources/DevToolsKitLicensing/Experimentation/TargetingRule.swift
+++ b/Sources/DevToolsKitLicensing/Experimentation/TargetingRule.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// A local targeting rule for experiment eligibility or rollout gating.
+///
+/// All checks are local — no GPS, no network. Version comparisons use numeric
+/// component comparison (e.g., "15.2" < "15.10").
+public enum TargetingRule: Sendable, Hashable, Codable {
+    /// User's app version must be at least this value.
+    case minimumAppVersion(String)
+
+    /// User's app version must be at most this value.
+    case maximumAppVersion(String)
+
+    /// User's macOS version must be at least this value.
+    case minimumOSVersion(String)
+
+    /// User's macOS version must be at most this value.
+    case maximumOSVersion(String)
+
+    /// User's system language code must match (e.g., `"en"`, `"ja"`).
+    case language(String)
+
+    /// User's system region code must match (e.g., `"US"`, `"JP"`).
+    case region(String)
+
+    /// Evaluate whether this rule is satisfied on the current system.
+    ///
+    /// - Returns: `true` if the user's environment matches the rule.
+    public func isSatisfied() -> Bool {
+        switch self {
+        case .minimumAppVersion(let version):
+            guard let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+            else { return false }
+            return compareVersions(appVersion, isAtLeast: version)
+
+        case .maximumAppVersion(let version):
+            guard let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+            else { return false }
+            return compareVersions(version, isAtLeast: appVersion)
+
+        case .minimumOSVersion(let version):
+            let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+            let osString = "\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)"
+            return compareVersions(osString, isAtLeast: version)
+
+        case .maximumOSVersion(let version):
+            let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+            let osString = "\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)"
+            return compareVersions(version, isAtLeast: osString)
+
+        case .language(let code):
+            let current = Locale.current.language.languageCode?.identifier ?? ""
+            return current == code
+
+        case .region(let code):
+            let current = Locale.current.region?.identifier ?? ""
+            return current == code
+        }
+    }
+}
+
+/// Compare two version strings numerically (e.g., "2.1.0" >= "2.0.3").
+private func compareVersions(_ lhs: String, isAtLeast rhs: String) -> Bool {
+    let lhsParts = lhs.split(separator: ".").compactMap { Int($0) }
+    let rhsParts = rhs.split(separator: ".").compactMap { Int($0) }
+    let maxCount = max(lhsParts.count, rhsParts.count)
+    for i in 0..<maxCount {
+        let l = i < lhsParts.count ? lhsParts[i] : 0
+        let r = i < rhsParts.count ? rhsParts[i] : 0
+        if l < r { return false }
+        if l > r { return true }
+    }
+    return true
+}

--- a/Sources/DevToolsKitLicensing/Panels/FeatureFlagsPanel/EnrollmentIDSectionView.swift
+++ b/Sources/DevToolsKitLicensing/Panels/FeatureFlagsPanel/EnrollmentIDSectionView.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+/// Displays the enrollment ID with its generation and expiry dates, plus manual reset.
+struct EnrollmentIDSectionView: View {
+    let licensing: LicensingManager
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                enrollmentSection
+                infoSection
+            }
+            .padding()
+        }
+    }
+
+    private var enrollmentSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Enrollment ID")
+                .font(.title3.weight(.semibold))
+
+            Text(licensing.enrollmentID.uuidString)
+                .font(.system(.body, design: .monospaced))
+                .textSelection(.enabled)
+
+            HStack(spacing: 12) {
+                Button("Copy") {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(
+                        licensing.enrollmentID.uuidString, forType: .string)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+
+                Button("Reset") {
+                    licensing.resetEnrollmentID()
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .tint(.orange)
+            }
+        }
+    }
+
+    private var infoSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Details")
+                .font(.title3.weight(.semibold))
+
+            infoRow("Generated", value: licensing.enrollment.generatedAt.formatted())
+            infoRow("Expires", value: licensing.enrollmentIDExpiresAt.formatted())
+            infoRow(
+                "Time Until Regeneration",
+                value: formatTimeRemaining(licensing.enrollmentIDExpiresAt.timeIntervalSinceNow))
+        }
+    }
+
+    private func infoRow(_ label: String, value: String) -> some View {
+        HStack {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(width: 180, alignment: .trailing)
+            Text(value)
+                .font(.system(.caption, design: .monospaced))
+                .textSelection(.enabled)
+        }
+    }
+
+    private func formatTimeRemaining(_ seconds: TimeInterval) -> String {
+        guard seconds > 0 else { return "Expired" }
+        let days = Int(seconds / 86400)
+        let hours = Int(seconds.truncatingRemainder(dividingBy: 86400) / 3600)
+        if days > 0 { return "\(days)d \(hours)h" }
+        let minutes = Int(seconds.truncatingRemainder(dividingBy: 3600) / 60)
+        if hours > 0 { return "\(hours)h \(minutes)m" }
+        return "\(minutes)m"
+    }
+}

--- a/Sources/DevToolsKitLicensing/Panels/FeatureFlagsPanel/FeatureFlagRowView.swift
+++ b/Sources/DevToolsKitLicensing/Panels/FeatureFlagsPanel/FeatureFlagRowView.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+/// A single feature flag row in the Feature Flags panel.
+struct FeatureFlagRowView: View {
+    let state: FeatureFlagState
+    let licensing: LicensingManager
+
+    var body: some View {
+        HStack(spacing: 10) {
+            statusDot
+            flagInfo
+            Spacer()
+            badges
+            overrideToggle
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var statusDot: some View {
+        Circle()
+            .fill(dotColor)
+            .frame(width: 8, height: 8)
+            .help(statusHelpText)
+    }
+
+    private var dotColor: Color {
+        if state.isOverridden { return .purple }
+        if state.isGated { return .orange }
+        if state.isEnabled { return .green }
+        return .gray
+    }
+
+    private var statusHelpText: String {
+        if state.isOverridden { return "Developer override active" }
+        if state.isGated { return "Gated by license tier" }
+        if state.isEnabled { return "Enabled" }
+        return "Disabled"
+    }
+
+    private var flagInfo: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 6) {
+                Text(state.definition.name)
+                    .font(.system(.body, weight: .medium))
+                Text(state.definition.id)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+            Text(state.definition.description)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+        }
+    }
+
+    @ViewBuilder
+    private var badges: some View {
+        if let cohort = state.cohort {
+            Text(cohort)
+                .font(.caption2)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(.blue.opacity(0.15), in: Capsule())
+                .foregroundStyle(.blue)
+        }
+
+        if state.isGated {
+            Image(systemName: "lock.fill")
+                .font(.caption)
+                .foregroundStyle(.orange)
+                .help("Requires higher license tier")
+        }
+
+        if let expiresAt = state.overrideExpiresAt {
+            let remaining = expiresAt.timeIntervalSinceNow
+            if remaining > 0 {
+                Text(formatTTL(remaining))
+                    .font(.caption2)
+                    .foregroundStyle(.purple)
+                    .help("Override expires at \(expiresAt.formatted())")
+            }
+        }
+    }
+
+    private var overrideToggle: some View {
+        Toggle(
+            isOn: Binding(
+                get: { state.isEnabled },
+                set: { newValue in
+                    licensing.setOverride(newValue, for: state.definition.id)
+                }
+            )
+        ) {
+            EmptyView()
+        }
+        .toggleStyle(.switch)
+        .controlSize(.small)
+    }
+
+    private func formatTTL(_ seconds: TimeInterval) -> String {
+        if seconds < 60 { return "\(Int(seconds))s" }
+        if seconds < 3600 { return "\(Int(seconds / 60))m" }
+        return "\(Int(seconds / 3600))h"
+    }
+}

--- a/Sources/DevToolsKitLicensing/Panels/FeatureFlagsPanel/FeatureFlagsPanel.swift
+++ b/Sources/DevToolsKitLicensing/Panels/FeatureFlagsPanel/FeatureFlagsPanel.swift
@@ -1,0 +1,30 @@
+import DevToolsKit
+import SwiftUI
+
+/// Built-in feature flags panel that displays flag states, license status, and experiments.
+///
+/// Opens with shortcut ⌘⌥F. Register with a `LicensingManager` instance:
+///
+/// ```swift
+/// let licensing = LicensingManager(keyPrefix: "myapp", backend: myBackend)
+/// manager.register(FeatureFlagsPanel(licensing: licensing))
+/// ```
+public struct FeatureFlagsPanel: DevToolPanel {
+    public let id = "devtools.feature-flags"
+    public let title = "Feature Flags"
+    public let icon = "flag"
+    public let keyboardShortcut = DevToolsKeyboardShortcut(key: "f")
+    public let preferredSize = CGSize(width: 800, height: 600)
+    public let minimumSize = CGSize(width: 600, height: 400)
+
+    private let licensing: LicensingManager
+
+    /// - Parameter licensing: The licensing manager to display and control.
+    public init(licensing: LicensingManager) {
+        self.licensing = licensing
+    }
+
+    public func makeBody() -> AnyView {
+        AnyView(FeatureFlagsPanelView(licensing: licensing))
+    }
+}

--- a/Sources/DevToolsKitLicensing/Panels/FeatureFlagsPanel/FeatureFlagsPanelView.swift
+++ b/Sources/DevToolsKitLicensing/Panels/FeatureFlagsPanel/FeatureFlagsPanelView.swift
@@ -1,0 +1,120 @@
+import DevToolsKit
+import SwiftUI
+
+/// Main view for the Feature Flags panel.
+public struct FeatureFlagsPanelView: View {
+    let licensing: LicensingManager
+    @State private var selectedTab = Tab.flags
+    @State private var searchText = ""
+
+    enum Tab: String, CaseIterable {
+        case flags = "Flags"
+        case license = "License"
+        case enrollment = "Enrollment"
+    }
+
+    public init(licensing: LicensingManager) {
+        self.licensing = licensing
+    }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            toolbar
+            Divider()
+            tabContent
+        }
+        .frame(minWidth: 600, minHeight: 400)
+    }
+
+    private var toolbar: some View {
+        HStack(spacing: 12) {
+            Picker("Tab", selection: $selectedTab) {
+                ForEach(Tab.allCases, id: \.self) { tab in
+                    Text(tab.rawValue).tag(tab)
+                }
+            }
+            .pickerStyle(.segmented)
+            .frame(maxWidth: 300)
+
+            if selectedTab == .flags {
+                TextField("Search flags...", text: $searchText)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: 200)
+            }
+
+            Spacer()
+
+            if selectedTab == .flags {
+                Text("\(licensing.flagDefinitions.count) flags")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Button("Clear Overrides") {
+                    licensing.clearAllOverrides()
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    @ViewBuilder
+    private var tabContent: some View {
+        switch selectedTab {
+        case .flags:
+            flagsList
+        case .license:
+            LicenseStatusSectionView(licensing: licensing)
+        case .enrollment:
+            EnrollmentIDSectionView(licensing: licensing)
+        }
+    }
+
+    private var flagsList: some View {
+        let states = licensing.allFlagStates
+        let grouped = Dictionary(grouping: states) { $0.definition.category }
+        let categories = grouped.keys.sorted()
+
+        let filtered: [(String, [FeatureFlagState])]
+        if searchText.isEmpty {
+            filtered = categories.compactMap { key in
+                grouped[key].map { (key, $0) }
+            }
+        } else {
+            filtered = categories.compactMap { category in
+                let matching = (grouped[category] ?? []).filter { state in
+                    state.definition.name.localizedCaseInsensitiveContains(searchText)
+                        || state.definition.id.localizedCaseInsensitiveContains(searchText)
+                        || state.definition.description.localizedCaseInsensitiveContains(searchText)
+                }
+                return matching.isEmpty ? nil : (category, matching)
+            }
+        }
+
+        return Group {
+            if filtered.isEmpty {
+                ContentUnavailableView(
+                    "No Feature Flags",
+                    systemImage: "flag",
+                    description: Text(
+                        searchText.isEmpty
+                            ? "Register flags with LicensingManager to see them here."
+                            : "No flags match your search.")
+                )
+            } else {
+                List {
+                    ForEach(filtered, id: \.0) { category, states in
+                        Section(category) {
+                            ForEach(states, id: \.definition.id) { state in
+                                FeatureFlagRowView(state: state, licensing: licensing)
+                            }
+                        }
+                    }
+                }
+                .listStyle(.inset)
+            }
+        }
+    }
+}

--- a/Sources/DevToolsKitLicensing/Panels/FeatureFlagsPanel/LicenseStatusSectionView.swift
+++ b/Sources/DevToolsKitLicensing/Panels/FeatureFlagsPanel/LicenseStatusSectionView.swift
@@ -1,0 +1,176 @@
+import SwiftUI
+
+/// License status display with activation controls.
+struct LicenseStatusSectionView: View {
+    let licensing: LicensingManager
+    @State private var showActivateSheet = false
+    @State private var licenseKeyInput = ""
+    @State private var offlineTokenInput = ""
+    @State private var activationError: String?
+    @State private var isActivating = false
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                statusSection
+                entitlementsSection
+                actionsSection
+            }
+            .padding()
+        }
+        .sheet(isPresented: $showActivateSheet) {
+            activateSheet
+        }
+    }
+
+    private var statusSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("License Status")
+                .font(.title3.weight(.semibold))
+
+            HStack(spacing: 8) {
+                Image(systemName: statusIcon)
+                    .foregroundStyle(statusColor)
+                Text(licensing.licenseStatus.rawValue.capitalized)
+                    .font(.headline)
+            }
+        }
+    }
+
+    private var statusIcon: String {
+        switch licensing.licenseStatus {
+        case .unconfigured: "questionmark.circle"
+        case .active: "checkmark.seal.fill"
+        case .offlineValid: "checkmark.shield.fill"
+        case .inactive: "xmark.circle"
+        case .invalid: "exclamationmark.triangle.fill"
+        case .pending: "clock"
+        }
+    }
+
+    private var statusColor: Color {
+        switch licensing.licenseStatus {
+        case .unconfigured: .gray
+        case .active, .offlineValid: .green
+        case .inactive: .orange
+        case .invalid: .red
+        case .pending: .blue
+        }
+    }
+
+    private var entitlementsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Active Entitlements")
+                .font(.title3.weight(.semibold))
+
+            let entitlements = Array(licensing.backend.activeEntitlements).sorted()
+            if entitlements.isEmpty {
+                Text("None")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            } else {
+                ForEach(entitlements, id: \.self) { entitlement in
+                    HStack(spacing: 6) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                            .font(.caption)
+                        Text(entitlement)
+                            .font(.system(.caption, design: .monospaced))
+                    }
+                }
+            }
+        }
+    }
+
+    private var actionsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Actions")
+                .font(.title3.weight(.semibold))
+
+            HStack(spacing: 12) {
+                Button("Activate License") {
+                    showActivateSheet = true
+                }
+                .buttonStyle(.bordered)
+
+                Button("Validate") {
+                    Task {
+                        try? await licensing.validate()
+                    }
+                }
+                .buttonStyle(.bordered)
+
+                Button("Deactivate") {
+                    Task {
+                        try? await licensing.deactivate()
+                    }
+                }
+                .buttonStyle(.bordered)
+                .tint(.red)
+            }
+        }
+    }
+
+    private var activateSheet: some View {
+        VStack(spacing: 16) {
+            Text("Activate License")
+                .font(.headline)
+
+            TextField("License Key", text: $licenseKeyInput)
+                .textFieldStyle(.roundedBorder)
+
+            Divider()
+
+            Text("Or paste offline token:")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            TextEditor(text: $offlineTokenInput)
+                .font(.system(.caption, design: .monospaced))
+                .frame(height: 80)
+                .border(Color.secondary.opacity(0.3))
+
+            if let error = activationError {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
+            HStack {
+                Button("Cancel") {
+                    showActivateSheet = false
+                    activationError = nil
+                }
+                .buttonStyle(.bordered)
+
+                Spacer()
+
+                Button("Activate") {
+                    Task { await performActivation() }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(licenseKeyInput.isEmpty && offlineTokenInput.isEmpty)
+                .disabled(isActivating)
+            }
+        }
+        .padding()
+        .frame(width: 400)
+    }
+
+    private func performActivation() async {
+        isActivating = true
+        activationError = nil
+        defer { isActivating = false }
+
+        do {
+            if !offlineTokenInput.isEmpty {
+                try await licensing.activate(with: .offlineToken(offlineTokenInput))
+            } else {
+                try await licensing.activate(with: .licenseKey(licenseKeyInput))
+            }
+            showActivateSheet = false
+        } catch {
+            activationError = error.localizedDescription
+        }
+    }
+}

--- a/Sources/DevToolsKitLicensingSeat/LicenseSeatBackend.swift
+++ b/Sources/DevToolsKitLicensingSeat/LicenseSeatBackend.swift
@@ -1,0 +1,108 @@
+import DevToolsKitLicensing
+import Foundation
+import LicenseSeat
+
+/// License backend for website-distributed apps using LicenseSeat + LemonSqueezy.
+///
+/// Wraps the LicenseSeat SDK to conform to ``LicenseBackend``. Supports both
+/// online license key activation and offline token validation.
+///
+/// ```swift
+/// import DevToolsKitLicensingSeat
+///
+/// let backend = LicenseSeatBackend(
+///     apiKey: "prod_xxx",
+///     productSlug: "my-product"
+/// )
+/// let licensing = LicensingManager(keyPrefix: "myapp", backend: backend)
+/// ```
+@MainActor
+public final class LicenseSeatBackend: LicenseBackend, @unchecked Sendable {
+    private let store: LicenseSeatStore
+    private let seat: LicenseSeat
+    private let entitlementKeys: [String]
+
+    /// Current license status mapped from LicenseSeat's status.
+    public private(set) var status: DevToolsLicenseStatus = .unconfigured
+
+    /// Active entitlement names from the LicenseSeat session.
+    public private(set) var activeEntitlements: Set<String> = []
+
+    /// - Parameters:
+    ///   - apiKey: The LicenseSeat API key.
+    ///   - productSlug: The LemonSqueezy product slug for this app.
+    ///   - entitlementKeys: Entitlement keys to check against the LicenseSeat API.
+    public init(apiKey: String, productSlug: String, entitlementKeys: [String] = []) {
+        self.entitlementKeys = entitlementKeys
+        self.store = LicenseSeatStore.shared
+        store.configure(apiKey: apiKey)
+
+        var config = LicenseSeatConfig.default
+        config.apiKey = apiKey
+        config.productSlug = productSlug
+        self.seat = LicenseSeat(config: config)
+
+        syncStatus()
+    }
+
+    public func activate(with credential: LicenseCredential) async throws {
+        switch credential {
+        case .licenseKey(let key):
+            try await store.activate(key)
+        case .offlineToken(let token):
+            // For offline tokens, activate with the token as a key and rely on
+            // the SDK's offline validation path
+            try await store.activate(token)
+        }
+        syncStatus()
+    }
+
+    public func validate() async throws {
+        guard let license = seat.currentLicense() else {
+            throw LicenseSeatStoreError.notConfigured
+        }
+        _ = try await seat.validate(licenseKey: license.licenseKey)
+        syncStatus()
+    }
+
+    public func deactivate() async throws {
+        try await store.deactivate()
+        status = .inactive
+        activeEntitlements = []
+    }
+
+    private func syncStatus() {
+        let seatStatus = store.status
+        status = mapStatus(seatStatus)
+        activeEntitlements = resolveEntitlements()
+    }
+
+    private func mapStatus(_ seatStatus: LicenseStatus) -> DevToolsLicenseStatus {
+        switch seatStatus {
+        case .active:
+            return .active
+        case .offlineValid:
+            return .offlineValid
+        case .inactive:
+            return .inactive
+        case .invalid, .offlineInvalid:
+            return .invalid
+        case .pending:
+            return .pending
+        }
+    }
+
+    private func resolveEntitlements() -> Set<String> {
+        var entitlements: Set<String> = []
+        if status == .active || status == .offlineValid {
+            entitlements.insert("premium")
+        }
+        for key in entitlementKeys {
+            let result = store.entitlement(key)
+            if result.active {
+                entitlements.insert(key)
+            }
+        }
+        return entitlements
+    }
+}

--- a/Sources/DevToolsKitLicensingStoreKit/StoreKitBackend.swift
+++ b/Sources/DevToolsKitLicensingStoreKit/StoreKitBackend.swift
@@ -1,0 +1,94 @@
+import DevToolsKitLicensing
+import Foundation
+import StoreKit
+
+/// License backend for App Store-distributed apps using StoreKit 2.
+///
+/// Maps StoreKit product IDs to named entitlement strings. The backend monitors
+/// transaction updates and resolves entitlements from current subscriptions and
+/// purchased products.
+///
+/// ```swift
+/// import DevToolsKitLicensingStoreKit
+///
+/// let backend = StoreKitBackend(entitlementMap: [
+///     "com.myapp.pro.monthly": ["premium"],
+///     "com.myapp.enterprise": ["premium", "enterprise"],
+/// ])
+/// let licensing = LicensingManager(keyPrefix: "myapp", backend: backend)
+/// ```
+@MainActor
+public final class StoreKitBackend: LicenseBackend, @unchecked Sendable {
+    /// Maps product IDs to the entitlement names they grant.
+    private let entitlementMap: [String: [String]]
+
+    /// Current license status.
+    public private(set) var status: DevToolsLicenseStatus = .unconfigured
+
+    /// Active entitlement names resolved from current StoreKit transactions.
+    public private(set) var activeEntitlements: Set<String> = []
+
+    private var transactionListener: Task<Void, Never>?
+
+    /// - Parameter entitlementMap: Dictionary mapping StoreKit product IDs to entitlement name arrays.
+    public init(entitlementMap: [String: [String]]) {
+        self.entitlementMap = entitlementMap
+        startTransactionListener()
+        Task { await refreshEntitlements() }
+    }
+
+    deinit {
+        transactionListener?.cancel()
+    }
+
+    public func activate(with credential: LicenseCredential) async throws {
+        // StoreKit handles purchases via its own UI. This is a no-op; the
+        // transaction listener picks up purchases automatically.
+        await refreshEntitlements()
+    }
+
+    public func validate() async throws {
+        await refreshEntitlements()
+    }
+
+    public func deactivate() async throws {
+        // Cannot programmatically cancel a subscription — user must do this
+        // through system settings. We just refresh the state.
+        await refreshEntitlements()
+    }
+
+    // MARK: - Transaction Monitoring
+
+    private func startTransactionListener() {
+        transactionListener = Task(priority: .utility) { [weak self] in
+            for await result in Transaction.updates {
+                guard let self else { return }
+                if case .verified = result {
+                    await self.refreshEntitlements()
+                }
+            }
+        }
+    }
+
+    private func refreshEntitlements() async {
+        var newEntitlements: Set<String> = []
+
+        for await result in Transaction.currentEntitlements {
+            if case .verified(let transaction) = result {
+                if let entitlements = entitlementMap[transaction.productID] {
+                    for entitlement in entitlements {
+                        newEntitlements.insert(entitlement)
+                    }
+                }
+            }
+        }
+
+        activeEntitlements = newEntitlements
+
+        if newEntitlements.isEmpty {
+            status = .inactive
+        } else {
+            status = .active
+        }
+    }
+}

--- a/Tests/DevToolsKitLicensingTests/CohortResolverTests.swift
+++ b/Tests/DevToolsKitLicensingTests/CohortResolverTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Testing
+
+@testable import DevToolsKitLicensing
+
+@Suite
+struct CohortResolverTests {
+    @Test func bucketIsDeterministic() {
+        let id = UUID()
+        let bucket1 = CohortResolver.bucket(enrollmentID: id, flagID: "test.flag")
+        let bucket2 = CohortResolver.bucket(enrollmentID: id, flagID: "test.flag")
+        #expect(bucket1 == bucket2)
+    }
+
+    @Test func bucketIsInRange() {
+        for _ in 0..<100 {
+            let bucket = CohortResolver.bucket(enrollmentID: UUID(), flagID: "test.flag")
+            #expect(bucket >= 0)
+            #expect(bucket < 100)
+        }
+    }
+
+    @Test func differentFlagsGetDifferentBuckets() {
+        let id = UUID()
+        let bucket1 = CohortResolver.bucket(enrollmentID: id, flagID: "test.flag-a")
+        let bucket2 = CohortResolver.bucket(enrollmentID: id, flagID: "test.flag-b")
+        // Not guaranteed to differ, but very likely with different inputs
+        // We test determinism instead
+        let bucket1Again = CohortResolver.bucket(enrollmentID: id, flagID: "test.flag-a")
+        #expect(bucket1 == bucket1Again)
+        _ = bucket2  // suppress unused warning
+    }
+
+    @Test func assignCohortDeterministic() {
+        let id = UUID()
+        let cohorts = [
+            Cohort(name: "control", weight: 50),
+            Cohort(name: "variant", weight: 50),
+        ]
+
+        let cohort1 = CohortResolver.assignCohort(
+            enrollmentID: id, flagID: "test.exp", cohorts: cohorts)
+        let cohort2 = CohortResolver.assignCohort(
+            enrollmentID: id, flagID: "test.exp", cohorts: cohorts)
+        #expect(cohort1 == cohort2)
+    }
+
+    @Test func assignCohortEmptyCohorts() {
+        let result = CohortResolver.assignCohort(
+            enrollmentID: UUID(), flagID: "test", cohorts: [])
+        #expect(result == nil)
+    }
+
+    @Test func assignCohortAllUsersAssigned() {
+        let cohorts = [
+            Cohort(name: "control", weight: 50),
+            Cohort(name: "variant-a", weight: 25),
+            Cohort(name: "variant-b", weight: 25),
+        ]
+
+        var assignments: [String: Int] = [:]
+        for _ in 0..<1000 {
+            let cohort = CohortResolver.assignCohort(
+                enrollmentID: UUID(), flagID: "test.multi", cohorts: cohorts)
+            #expect(cohort != nil)
+            assignments[cohort!, default: 0] += 1
+        }
+
+        // All three cohorts should have some assignments
+        #expect(assignments.keys.count == 3)
+        #expect(assignments["control"]! > 0)
+        #expect(assignments["variant-a"]! > 0)
+        #expect(assignments["variant-b"]! > 0)
+    }
+
+    @Test func isInRolloutDeterministic() {
+        let id = UUID()
+        let result1 = CohortResolver.isInRollout(
+            enrollmentID: id, flagID: "test.rollout", percentage: 50)
+        let result2 = CohortResolver.isInRollout(
+            enrollmentID: id, flagID: "test.rollout", percentage: 50)
+        #expect(result1 == result2)
+    }
+
+    @Test func rollout0PercentNeverEnabled() {
+        for _ in 0..<100 {
+            let result = CohortResolver.isInRollout(
+                enrollmentID: UUID(), flagID: "test.zero", percentage: 0)
+            #expect(result == false)
+        }
+    }
+
+    @Test func rollout100PercentAlwaysEnabled() {
+        for _ in 0..<100 {
+            let result = CohortResolver.isInRollout(
+                enrollmentID: UUID(), flagID: "test.full", percentage: 100)
+            #expect(result == true)
+        }
+    }
+}

--- a/Tests/DevToolsKitLicensingTests/CustomEntitlementTests.swift
+++ b/Tests/DevToolsKitLicensingTests/CustomEntitlementTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+
+@testable import DevToolsKitLicensing
+
+@Suite(.serialized)
+@MainActor
+struct CustomEntitlementTests {
+    @Test func customTierGatedWithoutEntitlement() {
+        let backend = MockBackend()
+        let prefix = "test.\(UUID().uuidString)"
+        let manager = LicensingManager(keyPrefix: prefix, backend: backend)
+
+        let flag = FeatureFlagDefinition(
+            id: "test.enterprise", name: "Enterprise", description: "Test", category: "Premium",
+            defaultEnabled: true, requiredTier: .custom("enterprise"))
+        manager.registerFlag(flag)
+
+        let state = manager.flagState(for: "test.enterprise")
+        #expect(state?.isEnabled == false)
+        #expect(state?.isGated == true)
+    }
+
+    @Test func customTierEnabledWithEntitlement() {
+        let backend = MockBackend()
+        backend.activeEntitlements = ["enterprise"]
+        let prefix = "test.\(UUID().uuidString)"
+        let manager = LicensingManager(keyPrefix: prefix, backend: backend)
+
+        let flag = FeatureFlagDefinition(
+            id: "test.enterprise", name: "Enterprise", description: "Test", category: "Premium",
+            defaultEnabled: true, requiredTier: .custom("enterprise"))
+        manager.registerFlag(flag)
+
+        let state = manager.flagState(for: "test.enterprise")
+        #expect(state?.isEnabled == true)
+        #expect(state?.isGated == false)
+    }
+
+    @Test func hasEntitlementDelegates() {
+        let backend = MockBackend()
+        backend.activeEntitlements = ["feature-a", "feature-b"]
+        let prefix = "test.\(UUID().uuidString)"
+        let manager = LicensingManager(keyPrefix: prefix, backend: backend)
+
+        #expect(manager.hasEntitlement("feature-a") == true)
+        #expect(manager.hasEntitlement("feature-b") == true)
+        #expect(manager.hasEntitlement("feature-c") == false)
+    }
+
+    @Test func overrideBypassesCustomEntitlement() {
+        let backend = MockBackend()
+        let prefix = "test.\(UUID().uuidString)"
+        let manager = LicensingManager(keyPrefix: prefix, backend: backend)
+
+        let flag = FeatureFlagDefinition(
+            id: "test.custom-override", name: "Custom", description: "Test", category: "Premium",
+            defaultEnabled: true, requiredTier: .custom("special"))
+        manager.registerFlag(flag)
+
+        #expect(manager.isEnabled("test.custom-override") == false)  // gated
+
+        manager.setOverride(true, for: "test.custom-override")
+        #expect(manager.isEnabled("test.custom-override") == true)  // override bypasses gate
+    }
+}

--- a/Tests/DevToolsKitLicensingTests/DiagnosticProviderTests.swift
+++ b/Tests/DevToolsKitLicensingTests/DiagnosticProviderTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+
+@testable import DevToolsKitLicensing
+
+@Suite(.serialized)
+@MainActor
+struct DiagnosticProviderTests {
+    @Test func sectionNameIsLicensing() {
+        let backend = MockBackend()
+        let prefix = "test.\(UUID().uuidString)"
+        let manager = LicensingManager(keyPrefix: prefix, backend: backend)
+
+        #expect(manager.sectionName == "licensing")
+    }
+
+    @Test func collectReturnsDiagnosticData() async {
+        let backend = MockBackend()
+        backend.activeEntitlements = ["premium"]
+        let prefix = "test.\(UUID().uuidString)"
+        let manager = LicensingManager(keyPrefix: prefix, backend: backend)
+
+        let flag = FeatureFlagDefinition(
+            id: "test.diag", name: "Diag", description: "Test", category: "Test",
+            defaultEnabled: true)
+        manager.registerFlag(flag)
+
+        let result = await manager.collect()
+        // Verify we get a Codable value (if it encodes without error, it's valid)
+        let encoder = JSONEncoder()
+        let data = try? encoder.encode(AnyCodableWrapper(result))
+        #expect(data != nil)
+    }
+}
+
+/// Test helper for encoding any Codable value.
+private struct AnyCodableWrapper: Encodable {
+    private let encodeClosure: (Encoder) throws -> Void
+
+    init(_ value: any Codable & Sendable) {
+        self.encodeClosure = { encoder in
+            try value.encode(to: encoder)
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        try encodeClosure(encoder)
+    }
+}

--- a/Tests/DevToolsKitLicensingTests/EnrollmentIDTests.swift
+++ b/Tests/DevToolsKitLicensingTests/EnrollmentIDTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+
+@testable import DevToolsKitLicensing
+
+@Suite(.serialized)
+@MainActor
+struct EnrollmentIDTests {
+    @Test func generatesStableID() {
+        let prefix = "test.\(UUID().uuidString)"
+        let enrollment = EnrollmentID(keyPrefix: prefix)
+
+        let id1 = enrollment.value
+        let id2 = enrollment.value
+        #expect(id1 == id2)
+    }
+
+    @Test func resetGeneratesNewID() {
+        let prefix = "test.\(UUID().uuidString)"
+        let enrollment = EnrollmentID(keyPrefix: prefix)
+
+        let original = enrollment.value
+        enrollment.reset()
+        let newID = enrollment.value
+        #expect(original != newID)
+    }
+
+    @Test func expiresAtIsInFuture() {
+        let prefix = "test.\(UUID().uuidString)"
+        let enrollment = EnrollmentID(keyPrefix: prefix)
+
+        _ = enrollment.value  // trigger generation
+        #expect(enrollment.expiresAt > Date())
+    }
+
+    @Test func generatedAtIsRecent() {
+        let prefix = "test.\(UUID().uuidString)"
+        let enrollment = EnrollmentID(keyPrefix: prefix)
+
+        _ = enrollment.value  // trigger generation
+        let now = Date()
+        #expect(abs(enrollment.generatedAt.timeIntervalSince(now)) < 2)
+    }
+
+    @Test func shortIntervalCausesRegeneration() {
+        let prefix = "test.\(UUID().uuidString)"
+        // Use a very short interval (already expired)
+        let enrollment = EnrollmentID(keyPrefix: prefix, regenerationInterval: -1)
+
+        let id1 = enrollment.value
+        let id2 = enrollment.value
+        // With negative interval, every access regenerates
+        #expect(id1 != id2)
+    }
+}

--- a/Tests/DevToolsKitLicensingTests/FeatureFlagDefinitionTests.swift
+++ b/Tests/DevToolsKitLicensingTests/FeatureFlagDefinitionTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+
+@testable import DevToolsKitLicensing
+
+@Suite
+struct FeatureFlagDefinitionTests {
+    @Test func defaultValues() {
+        let flag = FeatureFlagDefinition(
+            id: "test.flag", name: "Test", description: "Desc", category: "Cat")
+
+        #expect(flag.defaultEnabled == false)
+        #expect(flag.requiredTier == .free)
+        #expect(flag.rollout == nil)
+        #expect(flag.experiment == nil)
+    }
+
+    @Test func hashableConformance() {
+        let flag1 = FeatureFlagDefinition(
+            id: "test.a", name: "A", description: "Desc", category: "Cat")
+        let flag2 = FeatureFlagDefinition(
+            id: "test.a", name: "A", description: "Desc", category: "Cat")
+        let flag3 = FeatureFlagDefinition(
+            id: "test.b", name: "B", description: "Desc", category: "Cat")
+
+        #expect(flag1 == flag2)
+        #expect(flag1 != flag3)
+    }
+
+    @Test func identifiableConformance() {
+        let flag = FeatureFlagDefinition(
+            id: "test.identifiable", name: "ID", description: "Desc", category: "Cat")
+        #expect(flag.id == "test.identifiable")
+    }
+
+    @Test func withRollout() {
+        let rollout = RolloutDefinition(percentage: 50)
+        let flag = FeatureFlagDefinition(
+            id: "test.rollout", name: "Rollout", description: "Desc", category: "Cat",
+            rollout: rollout)
+
+        #expect(flag.rollout?.percentage == 50)
+    }
+
+    @Test func withExperiment() {
+        let experiment = CohortDefinition(cohorts: [
+            Cohort(name: "control", weight: 50),
+            Cohort(name: "variant", weight: 50),
+        ])
+        let flag = FeatureFlagDefinition(
+            id: "test.exp", name: "Exp", description: "Desc", category: "Cat",
+            experiment: experiment)
+
+        #expect(flag.experiment?.cohorts.count == 2)
+    }
+
+    @Test func licenseTierEquality() {
+        #expect(LicenseTier.free == LicenseTier.free)
+        #expect(LicenseTier.premium == LicenseTier.premium)
+        #expect(LicenseTier.custom("a") == LicenseTier.custom("a"))
+        #expect(LicenseTier.custom("a") != LicenseTier.custom("b"))
+        #expect(LicenseTier.free != LicenseTier.premium)
+    }
+}

--- a/Tests/DevToolsKitLicensingTests/LicensingManagerTests.swift
+++ b/Tests/DevToolsKitLicensingTests/LicensingManagerTests.swift
@@ -1,0 +1,255 @@
+import Foundation
+import Testing
+
+@testable import DevToolsKitLicensing
+
+@Suite(.serialized)
+@MainActor
+struct LicensingManagerTests {
+    private func makeManager(
+        backend: MockBackend = MockBackend()
+    ) -> (LicensingManager, MockBackend) {
+        let prefix = "test.\(UUID().uuidString)"
+        let manager = LicensingManager(keyPrefix: prefix, backend: backend)
+        return (manager, backend)
+    }
+
+    // MARK: - Registration
+
+    @Test func registerFlags() {
+        let (manager, _) = makeManager()
+        let flag = FeatureFlagDefinition(
+            id: "test.flag1", name: "Flag 1", description: "Test", category: "Test")
+        manager.registerFlags([flag])
+
+        #expect(manager.flagDefinitions.count == 1)
+        #expect(manager.flagOrder == ["test.flag1"])
+    }
+
+    @Test func duplicateFlagIgnored() {
+        let (manager, _) = makeManager()
+        let flag = FeatureFlagDefinition(
+            id: "test.flag1", name: "Flag 1", description: "Test", category: "Test")
+        manager.registerFlags([flag, flag])
+
+        #expect(manager.flagDefinitions.count == 1)
+    }
+
+    @Test func registerSingleFlag() {
+        let (manager, _) = makeManager()
+        let flag = FeatureFlagDefinition(
+            id: "test.single", name: "Single", description: "Test", category: "Test")
+        manager.registerFlag(flag)
+
+        #expect(manager.flagDefinitions["test.single"] != nil)
+    }
+
+    // MARK: - Default Resolution
+
+    @Test func defaultEnabledFlag() {
+        let (manager, _) = makeManager()
+        let flag = FeatureFlagDefinition(
+            id: "test.default-on", name: "On", description: "Test", category: "Test",
+            defaultEnabled: true)
+        manager.registerFlag(flag)
+
+        #expect(manager.isEnabled("test.default-on") == true)
+    }
+
+    @Test func defaultDisabledFlag() {
+        let (manager, _) = makeManager()
+        let flag = FeatureFlagDefinition(
+            id: "test.default-off", name: "Off", description: "Test", category: "Test",
+            defaultEnabled: false)
+        manager.registerFlag(flag)
+
+        #expect(manager.isEnabled("test.default-off") == false)
+    }
+
+    @Test func unregisteredFlagReturnsFalse() {
+        let (manager, _) = makeManager()
+        #expect(manager.isEnabled("nonexistent") == false)
+    }
+
+    @Test func unregisteredFlagStateIsNil() {
+        let (manager, _) = makeManager()
+        #expect(manager.flagState(for: "nonexistent") == nil)
+    }
+
+    // MARK: - License Gating
+
+    @Test func premiumFlagGatedWhenInactive() {
+        let (manager, _) = makeManager()
+        let flag = FeatureFlagDefinition(
+            id: "test.premium", name: "Premium", description: "Test", category: "Test",
+            defaultEnabled: true, requiredTier: .premium)
+        manager.registerFlag(flag)
+
+        let state = manager.flagState(for: "test.premium")
+        #expect(state?.isEnabled == false)
+        #expect(state?.isGated == true)
+    }
+
+    @Test func premiumFlagEnabledWhenActive() async throws {
+        let backend = MockBackend()
+        let (manager, _) = makeManager(backend: backend)
+        try await manager.activate(with: .licenseKey("test-key"))
+
+        let flag = FeatureFlagDefinition(
+            id: "test.premium", name: "Premium", description: "Test", category: "Test",
+            defaultEnabled: true, requiredTier: .premium)
+        manager.registerFlag(flag)
+
+        let state = manager.flagState(for: "test.premium")
+        #expect(state?.isEnabled == true)
+        #expect(state?.isGated == false)
+    }
+
+    @Test func freeTierAlwaysSatisfied() {
+        let (manager, _) = makeManager()
+        let flag = FeatureFlagDefinition(
+            id: "test.free", name: "Free", description: "Test", category: "Test",
+            defaultEnabled: true, requiredTier: .free)
+        manager.registerFlag(flag)
+
+        #expect(manager.isEnabled("test.free") == true)
+    }
+
+    // MARK: - Overrides
+
+    @Test func overrideEnablesDisabledFlag() {
+        let (manager, _) = makeManager()
+        let flag = FeatureFlagDefinition(
+            id: "test.disabled", name: "Disabled", description: "Test", category: "Test",
+            defaultEnabled: false)
+        manager.registerFlag(flag)
+
+        manager.setOverride(true, for: "test.disabled")
+        let state = manager.flagState(for: "test.disabled")
+        #expect(state?.isEnabled == true)
+        #expect(state?.isOverridden == true)
+    }
+
+    @Test func overrideDisablesEnabledFlag() {
+        let (manager, _) = makeManager()
+        let flag = FeatureFlagDefinition(
+            id: "test.enabled", name: "Enabled", description: "Test", category: "Test",
+            defaultEnabled: true)
+        manager.registerFlag(flag)
+
+        manager.setOverride(false, for: "test.enabled")
+        #expect(manager.isEnabled("test.enabled") == false)
+    }
+
+    @Test func clearOverride() {
+        let (manager, _) = makeManager()
+        let flag = FeatureFlagDefinition(
+            id: "test.flag", name: "Flag", description: "Test", category: "Test",
+            defaultEnabled: false)
+        manager.registerFlag(flag)
+
+        manager.setOverride(true, for: "test.flag")
+        #expect(manager.isEnabled("test.flag") == true)
+
+        manager.clearOverride(for: "test.flag")
+        #expect(manager.isEnabled("test.flag") == false)
+    }
+
+    @Test func clearAllOverrides() {
+        let (manager, _) = makeManager()
+        let flag1 = FeatureFlagDefinition(
+            id: "test.f1", name: "F1", description: "Test", category: "Test", defaultEnabled: false)
+        let flag2 = FeatureFlagDefinition(
+            id: "test.f2", name: "F2", description: "Test", category: "Test", defaultEnabled: false)
+        manager.registerFlags([flag1, flag2])
+
+        manager.setOverride(true, for: "test.f1")
+        manager.setOverride(true, for: "test.f2")
+        manager.clearAllOverrides()
+
+        #expect(manager.isEnabled("test.f1") == false)
+        #expect(manager.isEnabled("test.f2") == false)
+    }
+
+    @Test func overrideBypassesLicenseGating() {
+        let (manager, _) = makeManager()
+        let flag = FeatureFlagDefinition(
+            id: "test.gated", name: "Gated", description: "Test", category: "Test",
+            defaultEnabled: true, requiredTier: .premium)
+        manager.registerFlag(flag)
+
+        manager.setOverride(true, for: "test.gated")
+        let state = manager.flagState(for: "test.gated")
+        #expect(state?.isEnabled == true)
+        #expect(state?.isOverridden == true)
+        #expect(state?.isGated == false)
+    }
+
+    // MARK: - License Actions
+
+    @Test func activateDelegatesToBackend() async throws {
+        let backend = MockBackend()
+        let (manager, _) = makeManager(backend: backend)
+
+        try await manager.activate(with: .licenseKey("key-123"))
+        #expect(backend.activateCallCount == 1)
+        #expect(manager.licenseStatus == .active)
+    }
+
+    @Test func validateDelegatesToBackend() async throws {
+        let backend = MockBackend()
+        let (manager, _) = makeManager(backend: backend)
+
+        try await manager.validate()
+        #expect(backend.validateCallCount == 1)
+    }
+
+    @Test func deactivateDelegatesToBackend() async throws {
+        let backend = MockBackend()
+        let (manager, _) = makeManager(backend: backend)
+
+        try await manager.deactivate()
+        #expect(backend.deactivateCallCount == 1)
+        #expect(manager.licenseStatus == .inactive)
+    }
+
+    // MARK: - Entitlements
+
+    @Test func hasEntitlementDelegatesToBackend() {
+        let backend = MockBackend()
+        backend.activeEntitlements = ["enterprise"]
+        let (manager, _) = makeManager(backend: backend)
+
+        #expect(manager.hasEntitlement("enterprise") == true)
+        #expect(manager.hasEntitlement("nonexistent") == false)
+    }
+
+    // MARK: - State Version
+
+    @Test func stateVersionIncrements() {
+        let (manager, _) = makeManager()
+        let flag = FeatureFlagDefinition(
+            id: "test.flag", name: "Flag", description: "Test", category: "Test")
+        manager.registerFlag(flag)
+
+        let v0 = manager.stateVersion
+        manager.setOverride(true, for: "test.flag")
+        #expect(manager.stateVersion > v0)
+    }
+
+    // MARK: - All Flag States
+
+    @Test func allFlagStatesReturnsInOrder() {
+        let (manager, _) = makeManager()
+        let f1 = FeatureFlagDefinition(
+            id: "test.first", name: "First", description: "Test", category: "A")
+        let f2 = FeatureFlagDefinition(
+            id: "test.second", name: "Second", description: "Test", category: "B")
+        manager.registerFlags([f1, f2])
+
+        let states = manager.allFlagStates
+        #expect(states.count == 2)
+        #expect(states[0].definition.id == "test.first")
+        #expect(states[1].definition.id == "test.second")
+    }
+}

--- a/Tests/DevToolsKitLicensingTests/MockBackend.swift
+++ b/Tests/DevToolsKitLicensingTests/MockBackend.swift
@@ -1,0 +1,31 @@
+import DevToolsKitLicensing
+import Foundation
+
+/// Mock license backend for testing.
+@MainActor
+final class MockBackend: LicenseBackend {
+    var status: DevToolsLicenseStatus = .unconfigured
+    var activeEntitlements: Set<String> = []
+
+    var activateCallCount = 0
+    var validateCallCount = 0
+    var deactivateCallCount = 0
+    var lastCredential: LicenseCredential?
+
+    func activate(with credential: LicenseCredential) async throws {
+        activateCallCount += 1
+        lastCredential = credential
+        status = .active
+        activeEntitlements.insert("premium")
+    }
+
+    func validate() async throws {
+        validateCallCount += 1
+    }
+
+    func deactivate() async throws {
+        deactivateCallCount += 1
+        status = .inactive
+        activeEntitlements = []
+    }
+}

--- a/Tests/DevToolsKitLicensingTests/OverrideExpiryTests.swift
+++ b/Tests/DevToolsKitLicensingTests/OverrideExpiryTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+
+@testable import DevToolsKitLicensing
+
+@Suite(.serialized)
+@MainActor
+struct OverrideExpiryTests {
+    @Test func overrideWithTTLShowsExpiry() {
+        let prefix = "test.\(UUID().uuidString)"
+        let backend = MockBackend()
+        let manager = LicensingManager(keyPrefix: prefix, backend: backend)
+
+        let flag = FeatureFlagDefinition(
+            id: "test.ttl", name: "TTL", description: "Test", category: "Test",
+            defaultEnabled: false)
+        manager.registerFlag(flag)
+
+        manager.setOverride(true, for: "test.ttl", expiresAfter: .seconds(3600))
+        let state = manager.flagState(for: "test.ttl")
+        #expect(state?.isOverridden == true)
+        #expect(state?.overrideExpiresAt != nil)
+    }
+
+    @Test func permanentOverrideHasNoExpiry() {
+        let prefix = "test.\(UUID().uuidString)"
+        let backend = MockBackend()
+        let manager = LicensingManager(keyPrefix: prefix, backend: backend)
+
+        let flag = FeatureFlagDefinition(
+            id: "test.permanent", name: "Perm", description: "Test", category: "Test",
+            defaultEnabled: false)
+        manager.registerFlag(flag)
+
+        manager.setOverride(true, for: "test.permanent")
+        let state = manager.flagState(for: "test.permanent")
+        #expect(state?.isOverridden == true)
+        #expect(state?.overrideExpiresAt == nil)
+    }
+
+    @Test func expiredOverrideFallsBackToDefault() {
+        let prefix = "test.\(UUID().uuidString)"
+        let backend = MockBackend()
+        let manager = LicensingManager(keyPrefix: prefix, backend: backend)
+
+        let flag = FeatureFlagDefinition(
+            id: "test.expired", name: "Expired", description: "Test", category: "Test",
+            defaultEnabled: false)
+        manager.registerFlag(flag)
+
+        // Set override with already-expired TTL
+        let overrideKey = "\(prefix).featureFlag.override.test.expired"
+        let existsKey = "\(prefix).featureFlag.override.test.expired.exists"
+        let expiryKey = "\(prefix).featureFlag.override.test.expired.expiresAt"
+        UserDefaults.standard.set(true, forKey: overrideKey)
+        UserDefaults.standard.set(true, forKey: existsKey)
+        UserDefaults.standard.set(
+            Date().addingTimeInterval(-10).timeIntervalSince1970, forKey: expiryKey)
+
+        let state = manager.flagState(for: "test.expired")
+        #expect(state?.isOverridden == false)
+        #expect(state?.isEnabled == false)  // falls back to defaultEnabled
+    }
+}

--- a/Tests/DevToolsKitLicensingTests/RolloutTests.swift
+++ b/Tests/DevToolsKitLicensingTests/RolloutTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+
+@testable import DevToolsKitLicensing
+
+@Suite(.serialized)
+@MainActor
+struct RolloutTests {
+    @Test func rolloutPercentageClamped() {
+        let over = RolloutDefinition(percentage: 150)
+        #expect(over.percentage == 100)
+
+        let under = RolloutDefinition(percentage: -10)
+        #expect(under.percentage == 0)
+    }
+
+    @Test func rolloutFlagResolution() {
+        let prefix = "test.\(UUID().uuidString)"
+        let backend = MockBackend()
+        let manager = LicensingManager(keyPrefix: prefix, backend: backend)
+
+        // 100% rollout with no targeting
+        let flag = FeatureFlagDefinition(
+            id: "test.full-rollout", name: "Full", description: "Test", category: "Test",
+            defaultEnabled: false, rollout: RolloutDefinition(percentage: 100))
+        manager.registerFlag(flag)
+
+        #expect(manager.isEnabled("test.full-rollout") == true)
+    }
+
+    @Test func zeroRolloutUsesDefault() {
+        let prefix = "test.\(UUID().uuidString)"
+        let backend = MockBackend()
+        let manager = LicensingManager(keyPrefix: prefix, backend: backend)
+
+        let flag = FeatureFlagDefinition(
+            id: "test.zero-rollout", name: "Zero", description: "Test", category: "Test",
+            defaultEnabled: true, rollout: RolloutDefinition(percentage: 0))
+        manager.registerFlag(flag)
+
+        // With 0% rollout, eligible users get false from rollout, so result is false
+        #expect(manager.isEnabled("test.zero-rollout") == false)
+    }
+
+    @Test func rolloutDistribution() {
+        // Statistical test: 50% rollout should give roughly half enabled
+        var enabledCount = 0
+        let trials = 1000
+        for _ in 0..<trials {
+            let prefix = "test.\(UUID().uuidString)"
+            let backend = MockBackend()
+            let manager = LicensingManager(keyPrefix: prefix, backend: backend)
+
+            let flag = FeatureFlagDefinition(
+                id: "test.half", name: "Half", description: "Test", category: "Test",
+                defaultEnabled: false, rollout: RolloutDefinition(percentage: 50))
+            manager.registerFlag(flag)
+
+            if manager.isEnabled("test.half") { enabledCount += 1 }
+        }
+
+        // Should be roughly 500, allow wide margin
+        #expect(enabledCount > 300)
+        #expect(enabledCount < 700)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #5

- Add **DevToolsKitLicensing** target: feature flag definitions, license gating, A/B experimentation (deterministic SHA256 cohort assignment), percentage rollout, targeting rules, developer overrides with optional TTL, enrollment IDs, swift-metrics analytics, `LicenseBackend` protocol, `DiagnosticProvider` conformance, and Feature Flags panel (⌘⌥F)
- Add **DevToolsKitLicensingSeat** target: `LicenseBackend` conformance wrapping the LicenseSeat SDK for website-distributed apps
- Add **DevToolsKitLicensingStoreKit** target: `LicenseBackend` conformance using StoreKit 2 transaction monitoring for App Store apps
- Add **`DistributionChannel`** enum to DevToolsKit core with build flag convention docs
- Add 54 new tests across 8 test suites (89 total tests, all passing)
- Update CLAUDE.md workflow rules and .gitignore

## Test plan

- [x] `swift build` — all 5 targets compile
- [x] `swift test` — 89 tests in 13 suites pass
- [x] `swift-format lint --recursive Sources/ Tests/` — clean
- [x] `swiftlint lint` — 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)