### PR TITLE
feat: Add DevToolsKitProcess module (#9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ Multi-product package:
 - **DevToolsKitLicensing** — feature flags & licensing (depends on DevToolsKit + swift-metrics): flags, experiments, license gating, panel
 - **DevToolsKitLicensingSeat** — LicenseSeat backend (depends on DevToolsKitLicensing + licenseseat-swift)
 - **DevToolsKitLicensingStoreKit** — StoreKit backend (depends on DevToolsKitLicensing)
+- **DevToolsKitProcess** — process execution (no external deps): executor, result, timeout
 
 ## Build & Test
 
@@ -80,6 +81,8 @@ docs/
 │   ├── API.md, GUIDE.md
 ├── licensing/                # DevToolsKitLicensing
 │   ├── API.md, FEATURE_FLAGS.md, EXPERIMENTATION.md, LICENSE_BACKENDS.md
+├── process/                  # DevToolsKitProcess
+│   ├── API.md, GUIDE.md
 ├── TESTING.md, AI_PROMPTS.md, CONTRIBUTING.md
 ```
 

--- a/Package.swift
+++ b/Package.swift
@@ -32,6 +32,10 @@ let package = Package(
             name: "DevToolsKitLicensingStoreKit",
             targets: ["DevToolsKitLicensingStoreKit"]
         ),
+        .library(
+            name: "DevToolsKitProcess",
+            targets: ["DevToolsKitProcess"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.0"),
@@ -94,6 +98,12 @@ let package = Package(
                 .swiftLanguageMode(.v6)
             ]
         ),
+        .target(
+            name: "DevToolsKitProcess",
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        ),
         .testTarget(
             name: "DevToolsKitTests",
             dependencies: ["DevToolsKit"],
@@ -118,6 +128,13 @@ let package = Package(
         .testTarget(
             name: "DevToolsKitLicensingTests",
             dependencies: ["DevToolsKitLicensing"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        ),
+        .testTarget(
+            name: "DevToolsKitProcessTests",
+            dependencies: ["DevToolsKitProcess"],
             swiftSettings: [
                 .swiftLanguageMode(.v6)
             ]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ DevToolsKit is a modular developer tools framework for macOS SwiftUI apps. Impor
 | **DevToolsKitLogging** | swift-log integration with filterable log viewer panel | [swift-log](https://github.com/apple/swift-log) |
 | **DevToolsKitMetrics** | swift-metrics integration with storage, query, and metrics inspector panel | [swift-metrics](https://github.com/apple/swift-metrics) |
 | **DevToolsKitLicensing** | Feature flags, cohort experiments, percentage rollouts, license-tier gating | [swift-metrics](https://github.com/apple/swift-metrics) |
+| **DevToolsKitProcess** | Process execution with timeout, stdout/stderr capture | None |
 
 ## Features
 
@@ -126,7 +127,7 @@ Or in Xcode: File > Add Package Dependencies, paste the repository URL.
 
 - **[Documentation Index](docs/INDEX.md)** — All docs, organized by module
 - [Quick Start](docs/core/QUICK_START.md) — Add DevToolsKit to your app in 4 steps
-- [Core API](docs/core/API.md) | [Logging API](docs/logging/API.md) | [Metrics API](docs/metrics/API.md) | [Licensing API](docs/licensing/API.md)
+- [Core API](docs/core/API.md) | [Logging API](docs/logging/API.md) | [Metrics API](docs/metrics/API.md) | [Licensing API](docs/licensing/API.md) | [Process API](docs/process/API.md)
 - [Feature Flags Guide](docs/licensing/FEATURE_FLAGS.md) — Define, gate, and override flags
 - [Testing Patterns](docs/TESTING.md) — Unit testing with DevToolsKit
 - [AI Coding Prompts](docs/AI_PROMPTS.md) — Template prompts for AI assistants

--- a/Sources/DevToolsKitProcess/ProcessExecutionError.swift
+++ b/Sources/DevToolsKitProcess/ProcessExecutionError.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Errors that can occur during process execution.
+///
+/// Since 0.4.0
+public enum ProcessExecutionError: Error, LocalizedError, Sendable {
+    /// The process was terminated because it exceeded the specified timeout.
+    case timeout(TimeInterval)
+
+    /// The process could not be started.
+    case executionFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .timeout(let seconds):
+            return "Process timed out after \(String(format: "%.1f", seconds)) seconds"
+        case .executionFailed(let reason):
+            return "Process execution failed: \(reason)"
+        }
+    }
+}

--- a/Sources/DevToolsKitProcess/ProcessExecutor.swift
+++ b/Sources/DevToolsKitProcess/ProcessExecutor.swift
@@ -1,0 +1,217 @@
+import Foundation
+import os
+
+/// Utility for executing external processes with consistent error handling and timeout support.
+///
+/// `ProcessExecutor` provides static methods for running external commands synchronously
+/// or asynchronously, with optional timeout enforcement.
+///
+/// ```swift
+/// // Synchronous execution
+/// let result = try ProcessExecutor.execute("/usr/bin/git", arguments: ["status"])
+///
+/// // Asynchronous with timeout
+/// let result = try await ProcessExecutor.executeAsync(
+///     "/usr/bin/swift", arguments: ["build"], timeout: 120
+/// )
+///
+/// // Shell command with pipes
+/// let result = try await ProcessExecutor.executeShell("ls -la | grep .swift")
+/// ```
+///
+/// Since 0.4.0
+public struct ProcessExecutor: Sendable {
+
+    private static let logger = Logger(
+        subsystem: "com.devtoolskit.process",
+        category: "ProcessExecutor"
+    )
+
+    // MARK: - Synchronous Execution
+
+    /// Executes a command synchronously.
+    /// - Parameters:
+    ///   - executable: Path to the executable.
+    ///   - arguments: Command arguments.
+    ///   - workingDirectory: Working directory (optional).
+    ///   - environment: Environment variables (optional, inherits current if nil).
+    /// - Returns: A ``ProcessResult`` with exit code and output.
+    /// - Throws: ``ProcessExecutionError/executionFailed(_:)`` if the process cannot start.
+    public static func execute(
+        _ executable: String,
+        arguments: [String] = [],
+        workingDirectory: URL? = nil,
+        environment: [String: String]? = nil
+    ) throws -> ProcessResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+
+        if let workingDirectory {
+            process.currentDirectoryURL = workingDirectory
+        }
+
+        if let environment {
+            process.environment = environment
+        }
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        let startTime = Date()
+
+        do {
+            try process.run()
+        } catch {
+            throw ProcessExecutionError.executionFailed(error.localizedDescription)
+        }
+
+        process.waitUntilExit()
+
+        let duration = Date().timeIntervalSince(startTime)
+
+        let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+
+        let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
+        let stderr = String(data: stderrData, encoding: .utf8) ?? ""
+
+        return ProcessResult(
+            exitCode: process.terminationStatus,
+            stdout: stdout,
+            stderr: stderr,
+            duration: duration,
+            startedAt: startTime
+        )
+    }
+
+    // MARK: - Asynchronous Execution with Timeout
+
+    /// Executes a command asynchronously with optional timeout support.
+    /// - Parameters:
+    ///   - executable: Path to the executable.
+    ///   - arguments: Command arguments.
+    ///   - workingDirectory: Working directory (optional).
+    ///   - environment: Environment variables (optional, inherits current if nil).
+    ///   - timeout: Maximum execution time in seconds (`nil` = no timeout).
+    /// - Returns: A ``ProcessResult`` with exit code and output.
+    /// - Throws: ``ProcessExecutionError/executionFailed(_:)`` if the process cannot start.
+    public static func executeAsync(
+        _ executable: String,
+        arguments: [String] = [],
+        workingDirectory: URL? = nil,
+        environment: [String: String]? = nil,
+        timeout: TimeInterval? = nil
+    ) async throws -> ProcessResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+
+        if let workingDirectory {
+            process.currentDirectoryURL = workingDirectory
+        }
+
+        if let environment {
+            process.environment = environment
+        }
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        let startTime = Date()
+
+        do {
+            try process.run()
+        } catch {
+            throw ProcessExecutionError.executionFailed(error.localizedDescription)
+        }
+
+        // Set up timeout if specified
+        var timeoutTask: Task<Void, Never>?
+        if let timeout {
+            timeoutTask = Task {
+                try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                if process.isRunning {
+                    logger.warning("Terminating process due to timeout (\(timeout)s)")
+                    process.terminate()
+                }
+            }
+        }
+
+        // Wait for process to finish
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            process.terminationHandler = { _ in
+                continuation.resume()
+            }
+        }
+
+        // Cancel timeout task if process finished
+        timeoutTask?.cancel()
+
+        let duration = Date().timeIntervalSince(startTime)
+
+        let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+
+        let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
+        let stderr = String(data: stderrData, encoding: .utf8) ?? ""
+
+        return ProcessResult(
+            exitCode: process.terminationStatus,
+            stdout: stdout,
+            stderr: stderr,
+            duration: duration,
+            startedAt: startTime
+        )
+    }
+
+    // MARK: - Shell Command Execution
+
+    /// Executes a shell command via `/bin/bash`.
+    /// - Parameters:
+    ///   - command: The shell command to execute.
+    ///   - workingDirectory: Working directory (optional).
+    ///   - timeout: Maximum execution time in seconds (`nil` = no timeout).
+    /// - Returns: A ``ProcessResult`` with exit code and output.
+    /// - Throws: ``ProcessExecutionError/executionFailed(_:)`` if the process cannot start.
+    public static func executeShell(
+        _ command: String,
+        workingDirectory: URL? = nil,
+        timeout: TimeInterval? = nil
+    ) async throws -> ProcessResult {
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+        return try await executeAsync(
+            "/bin/bash",
+            arguments: ["-c", command],
+            workingDirectory: workingDirectory,
+            environment: environment,
+            timeout: timeout
+        )
+    }
+
+    // MARK: - Output Formatting
+
+    /// Formats process output for display, combining stdout and stderr.
+    /// - Parameters:
+    ///   - result: The process result.
+    ///   - includeStderr: Whether to include stderr in output (default: `true`).
+    /// - Returns: Formatted output string.
+    public static func formatOutput(_ result: ProcessResult, includeStderr: Bool = true) -> String {
+        var output = result.stdout
+
+        if includeStderr && !result.stderr.isEmpty {
+            if !output.isEmpty {
+                output += "\n"
+            }
+            output += result.stderr
+        }
+
+        return output
+    }
+}

--- a/Sources/DevToolsKitProcess/ProcessResult.swift
+++ b/Sources/DevToolsKitProcess/ProcessResult.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// The result of an external process execution.
+///
+/// Contains the exit code, captured stdout/stderr output, timing information,
+/// and a unique identifier for tracking.
+///
+/// Since 0.4.0
+public struct ProcessResult: Sendable, Identifiable {
+    /// Unique identifier for this result.
+    public let id: UUID
+
+    /// The process exit code. A value of `0` typically indicates success.
+    public let exitCode: Int32
+
+    /// Standard output captured from the process.
+    public let stdout: String
+
+    /// Standard error captured from the process.
+    public let stderr: String
+
+    /// Wall-clock duration of the process execution in seconds.
+    public let duration: TimeInterval
+
+    /// When the process started executing.
+    public let startedAt: Date
+
+    /// Whether the process exited with code `0`.
+    public var succeeded: Bool {
+        exitCode == 0
+    }
+
+    /// Creates a new process result.
+    /// - Parameters:
+    ///   - id: Unique identifier (defaults to a new UUID).
+    ///   - exitCode: The process exit code.
+    ///   - stdout: Captured standard output.
+    ///   - stderr: Captured standard error.
+    ///   - duration: Execution duration in seconds.
+    ///   - startedAt: When the process started (defaults to now minus duration).
+    public init(
+        id: UUID = UUID(),
+        exitCode: Int32,
+        stdout: String,
+        stderr: String,
+        duration: TimeInterval,
+        startedAt: Date = Date()
+    ) {
+        self.id = id
+        self.exitCode = exitCode
+        self.stdout = stdout
+        self.stderr = stderr
+        self.duration = duration
+        self.startedAt = startedAt
+    }
+}

--- a/Tests/DevToolsKitProcessTests/ProcessExecutorTests.swift
+++ b/Tests/DevToolsKitProcessTests/ProcessExecutorTests.swift
@@ -1,0 +1,344 @@
+import Testing
+import Foundation
+@testable import DevToolsKitProcess
+
+@Suite("ProcessResult")
+struct ProcessResultTests {
+
+    @Test func succeededWhenExitCodeZero() {
+        let result = ProcessResult(exitCode: 0, stdout: "output", stderr: "", duration: 0.5)
+        #expect(result.succeeded)
+        #expect(result.exitCode == 0)
+        #expect(result.stdout == "output")
+        #expect(result.stderr == "")
+    }
+
+    @Test func failedWhenExitCodeNonZero() {
+        let result = ProcessResult(exitCode: 1, stdout: "", stderr: "error", duration: 0.2)
+        #expect(!result.succeeded)
+        #expect(result.exitCode == 1)
+        #expect(result.stderr == "error")
+    }
+
+    @Test func hasUniqueIdentifier() {
+        let a = ProcessResult(exitCode: 0, stdout: "", stderr: "", duration: 0)
+        let b = ProcessResult(exitCode: 0, stdout: "", stderr: "", duration: 0)
+        #expect(a.id != b.id)
+    }
+
+    @Test func recordsStartedAt() {
+        let now = Date()
+        let result = ProcessResult(exitCode: 0, stdout: "", stderr: "", duration: 0.1, startedAt: now)
+        #expect(result.startedAt == now)
+    }
+}
+
+@Suite("ProcessExecutor - Synchronous")
+struct ProcessExecutorSyncTests {
+
+    @Test func executeSuccess() throws {
+        let result = try ProcessExecutor.execute("/bin/echo", arguments: ["hello"])
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.contains("hello"))
+        #expect(result.succeeded)
+        #expect(result.duration >= 0)
+    }
+
+    @Test func executeWithArguments() throws {
+        let result = try ProcessExecutor.execute("/bin/echo", arguments: ["one", "two", "three"])
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.contains("one"))
+        #expect(result.stdout.contains("two"))
+        #expect(result.stdout.contains("three"))
+    }
+
+    @Test func executeWithStderr() throws {
+        let result = try ProcessExecutor.execute("/bin/ls", arguments: ["/nonexistent/path/xyz"])
+        #expect(result.exitCode != 0)
+        #expect(!result.succeeded)
+        #expect(!result.stderr.isEmpty)
+    }
+
+    @Test func executeWithWorkingDirectory() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+        let result = try ProcessExecutor.execute("/bin/pwd", workingDirectory: tempDir)
+        #expect(result.exitCode == 0)
+        #expect(
+            result.stdout.contains(tempDir.path)
+            || result.stdout.contains("/var")
+            || result.stdout.contains("/private")
+        )
+    }
+
+    @Test func executeInvalidExecutableThrows() {
+        #expect(throws: ProcessExecutionError.self) {
+            try ProcessExecutor.execute("/nonexistent/command")
+        }
+    }
+
+    @Test func executeTracksDuration() throws {
+        let result = try ProcessExecutor.execute("/bin/sleep", arguments: ["0.1"])
+        #expect(result.exitCode == 0)
+        #expect(result.duration > 0.05)
+        #expect(result.duration < 2.0)
+    }
+}
+
+@Suite("ProcessExecutor - Async")
+struct ProcessExecutorAsyncTests {
+
+    @Test func asyncSuccess() async throws {
+        let result = try await ProcessExecutor.executeAsync("/bin/echo", arguments: ["async test"])
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.contains("async test"))
+        #expect(result.succeeded)
+    }
+
+    @Test func asyncWithTimeout() async throws {
+        let result = try await ProcessExecutor.executeAsync(
+            "/bin/echo", arguments: ["quick"], timeout: 5.0
+        )
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.contains("quick"))
+    }
+
+    @Test func asyncTimeoutEnforcement() async throws {
+        let result = try await ProcessExecutor.executeAsync(
+            "/bin/sleep", arguments: ["2"], timeout: 0.5
+        )
+        // Process should be terminated (exit code 15 = SIGTERM)
+        #expect(result.exitCode != 0)
+        #expect(result.duration < 1.5)
+    }
+
+    @Test func asyncNoTimeout() async throws {
+        let result = try await ProcessExecutor.executeAsync(
+            "/bin/sleep", arguments: ["0.1"], timeout: nil
+        )
+        #expect(result.exitCode == 0)
+        #expect(result.succeeded)
+    }
+
+    @Test func asyncWithEnvironment() async throws {
+        let customEnv = ["TEST_VAR": "test_value"]
+        let result = try await ProcessExecutor.executeAsync(
+            "/usr/bin/printenv", arguments: ["TEST_VAR"], environment: customEnv
+        )
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.contains("test_value"))
+    }
+
+    @Test func asyncCapturesStdout() async throws {
+        let result = try await ProcessExecutor.executeAsync(
+            "/bin/echo", arguments: ["stdout output"]
+        )
+        #expect(result.stdout.contains("stdout output"))
+        #expect(result.stderr.isEmpty)
+    }
+
+    @Test func asyncCapturesStderr() async throws {
+        let result = try await ProcessExecutor.executeAsync(
+            "/bin/ls", arguments: ["/nonexistent/xyz123"]
+        )
+        #expect(!result.succeeded)
+        #expect(!result.stderr.isEmpty)
+    }
+}
+
+@Suite("ProcessExecutor - Shell")
+struct ProcessExecutorShellTests {
+
+    @Test func shellSimpleCommand() async throws {
+        let result = try await ProcessExecutor.executeShell("echo 'shell test'")
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.contains("shell test"))
+    }
+
+    @Test func shellWithPipe() async throws {
+        let result = try await ProcessExecutor.executeShell("echo 'hello world' | grep 'world'")
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.contains("world"))
+    }
+
+    @Test func shellWithRedirection() async throws {
+        let result = try await ProcessExecutor.executeShell(
+            "echo 'test' > /dev/null && echo 'done'"
+        )
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.contains("done"))
+    }
+
+    @Test func shellWithVariables() async throws {
+        let result = try await ProcessExecutor.executeShell("VAR='value' && echo $VAR")
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.contains("value"))
+    }
+
+    @Test func shellWithWorkingDirectory() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+        let result = try await ProcessExecutor.executeShell("pwd", workingDirectory: tempDir)
+        #expect(result.exitCode == 0)
+        #expect(
+            result.stdout.contains(tempDir.path)
+            || result.stdout.contains("/var")
+            || result.stdout.contains("/private")
+        )
+    }
+
+    @Test func shellWithTimeout() async throws {
+        let result = try await ProcessExecutor.executeShell("sleep 2", timeout: 0.5)
+        #expect(result.exitCode != 0)
+        #expect(result.duration < 1.5)
+    }
+
+    @Test func shellFailedCommand() async throws {
+        let result = try await ProcessExecutor.executeShell("exit 42")
+        #expect(result.exitCode == 42)
+        #expect(!result.succeeded)
+    }
+
+    @Test func shellMultipleCommands() async throws {
+        let result = try await ProcessExecutor.executeShell(
+            "echo 'one' && echo 'two' && echo 'three'"
+        )
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.contains("one"))
+        #expect(result.stdout.contains("two"))
+        #expect(result.stdout.contains("three"))
+    }
+
+    @Test func shellConditionalExecution() async throws {
+        let result = try await ProcessExecutor.executeShell("false || echo 'fallback'")
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.contains("fallback"))
+    }
+}
+
+@Suite("ProcessExecutor - Format Output")
+struct ProcessExecutorFormatOutputTests {
+
+    @Test func stdoutOnly() {
+        let result = ProcessResult(exitCode: 0, stdout: "output", stderr: "", duration: 0.1)
+        let formatted = ProcessExecutor.formatOutput(result)
+        #expect(formatted == "output")
+    }
+
+    @Test func stderrOnly() {
+        let result = ProcessResult(exitCode: 1, stdout: "", stderr: "error", duration: 0.1)
+        let formatted = ProcessExecutor.formatOutput(result)
+        #expect(formatted == "error")
+    }
+
+    @Test func bothStreams() {
+        let result = ProcessResult(exitCode: 0, stdout: "output", stderr: "warning", duration: 0.1)
+        let formatted = ProcessExecutor.formatOutput(result)
+        #expect(formatted == "output\nwarning")
+    }
+
+    @Test func excludeStderr() {
+        let result = ProcessResult(exitCode: 0, stdout: "output", stderr: "error", duration: 0.1)
+        let formatted = ProcessExecutor.formatOutput(result, includeStderr: false)
+        #expect(formatted == "output")
+        #expect(!formatted.contains("error"))
+    }
+
+    @Test func emptyOutput() {
+        let result = ProcessResult(exitCode: 0, stdout: "", stderr: "", duration: 0.1)
+        let formatted = ProcessExecutor.formatOutput(result)
+        #expect(formatted == "")
+    }
+}
+
+@Suite("ProcessExecutor - Edge Cases")
+struct ProcessExecutorEdgeCaseTests {
+
+    @Test func largeOutput() async throws {
+        let result = try await ProcessExecutor.executeAsync(
+            "/usr/bin/seq", arguments: ["1", "10000"]
+        )
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.count > 10000)
+        #expect(result.stdout.contains("10000"))
+    }
+
+    @Test func unicodeOutput() async throws {
+        let result = try await ProcessExecutor.executeAsync(
+            "/bin/echo", arguments: ["Hello \u{4e16}\u{754c} \u{1f30d}"]
+        )
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.contains("\u{4e16}\u{754c}"))
+    }
+
+    @Test func specialCharacters() async throws {
+        let result = try await ProcessExecutor.executeAsync(
+            "/bin/echo", arguments: ["$#@!%^&*()"]
+        )
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.contains("$#@!%^&*()"))
+    }
+
+    @Test func sequentialCalls() async throws {
+        for i in 1...5 {
+            let result = try await ProcessExecutor.executeAsync(
+                "/bin/echo", arguments: ["test \(i)"]
+            )
+            #expect(result.exitCode == 0)
+            #expect(result.stdout.contains("test \(i)"))
+        }
+    }
+
+    @Test func concurrentCalls() async throws {
+        await withTaskGroup(of: Bool.self) { group in
+            for i in 1...5 {
+                group.addTask {
+                    do {
+                        let result = try await ProcessExecutor.executeAsync(
+                            "/bin/echo", arguments: ["concurrent \(i)"]
+                        )
+                        return result.exitCode == 0
+                    } catch {
+                        return false
+                    }
+                }
+            }
+
+            var successCount = 0
+            for await success in group {
+                if success { successCount += 1 }
+            }
+
+            #expect(successCount == 5)
+        }
+    }
+
+    @Test func emptyStdoutStderr() async throws {
+        let result = try await ProcessExecutor.executeAsync("/usr/bin/true")
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.isEmpty)
+        #expect(result.stderr.isEmpty)
+    }
+
+    @Test func durationAccuracy() async throws {
+        let sleepDuration = 0.2
+        let result = try await ProcessExecutor.executeAsync(
+            "/bin/sleep", arguments: [String(sleepDuration)]
+        )
+        #expect(result.duration > sleepDuration * 0.8)
+        #expect(result.duration < sleepDuration * 5.0)
+    }
+}
+
+@Suite("ProcessExecutionError")
+struct ProcessExecutionErrorTests {
+
+    @Test func timeoutErrorDescription() {
+        let error = ProcessExecutionError.timeout(5.0)
+        #expect(error.localizedDescription.contains("timed out"))
+        #expect(error.localizedDescription.contains("5.0"))
+    }
+
+    @Test func executionFailedDescription() {
+        let error = ProcessExecutionError.executionFailed("file not found")
+        #expect(error.localizedDescription.contains("file not found"))
+    }
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,6 +12,7 @@ DevToolsKit is a multi-product Swift package. Import only what you need.
 | **[DevToolsKitLogging](logging/GUIDE.md)** | swift-log integration with filterable log viewer panel | DevToolsKit, [swift-log](https://github.com/apple/swift-log) |
 | **[DevToolsKitMetrics](metrics/GUIDE.md)** | swift-metrics integration with storage, query, and metrics inspector panel | DevToolsKit, [swift-metrics](https://github.com/apple/swift-metrics) |
 | **[DevToolsKitLicensing](licensing/FEATURE_FLAGS.md)** | Feature flags, experimentation (cohorts/rollouts), license gating | DevToolsKit, [swift-metrics](https://github.com/apple/swift-metrics) |
+| **[DevToolsKitProcess](process/GUIDE.md)** | Process execution with timeout, stdout/stderr capture | None |
 
 ## Quick Links
 
@@ -38,6 +39,10 @@ DevToolsKit is a multi-product Swift package. Import only what you need.
 - [Experimentation](licensing/EXPERIMENTATION.md) — Cohorts, percentage rollouts, targeting rules
 - [License Backends](licensing/LICENSE_BACKENDS.md) — Pluggable license validation
 - [Licensing API Reference](licensing/API.md)
+
+### Process Execution (opt-in)
+- [Process Guide](process/GUIDE.md) — Process execution with timeout and output capture
+- [Process API Reference](process/API.md)
 
 ### Cross-Module
 - [Testing Patterns](TESTING.md)

--- a/docs/process/API.md
+++ b/docs/process/API.md
@@ -1,0 +1,74 @@
+[< Guide](GUIDE.md) | [Index](../INDEX.md)
+
+# DevToolsKitProcess API Reference
+
+> Source: `Sources/DevToolsKitProcess/`
+> Since: 0.4.0
+
+## ProcessResult
+
+```swift
+public struct ProcessResult: Sendable, Identifiable {
+    public let id: UUID
+    public let exitCode: Int32
+    public let stdout: String
+    public let stderr: String
+    public let duration: TimeInterval
+    public let startedAt: Date
+    public var succeeded: Bool { get }
+
+    public init(
+        id: UUID = UUID(),
+        exitCode: Int32,
+        stdout: String,
+        stderr: String,
+        duration: TimeInterval,
+        startedAt: Date = Date()
+    )
+}
+```
+
+## ProcessExecutionError
+
+```swift
+public enum ProcessExecutionError: Error, LocalizedError, Sendable {
+    case timeout(TimeInterval)
+    case executionFailed(String)
+}
+```
+
+## ProcessExecutor
+
+```swift
+public struct ProcessExecutor: Sendable {
+    /// Executes a command synchronously.
+    public static func execute(
+        _ executable: String,
+        arguments: [String] = [],
+        workingDirectory: URL? = nil,
+        environment: [String: String]? = nil
+    ) throws -> ProcessResult
+
+    /// Executes a command asynchronously with optional timeout.
+    public static func executeAsync(
+        _ executable: String,
+        arguments: [String] = [],
+        workingDirectory: URL? = nil,
+        environment: [String: String]? = nil,
+        timeout: TimeInterval? = nil
+    ) async throws -> ProcessResult
+
+    /// Executes a shell command via /bin/bash.
+    public static func executeShell(
+        _ command: String,
+        workingDirectory: URL? = nil,
+        timeout: TimeInterval? = nil
+    ) async throws -> ProcessResult
+
+    /// Formats process output for display.
+    public static func formatOutput(
+        _ result: ProcessResult,
+        includeStderr: Bool = true
+    ) -> String
+}
+```

--- a/docs/process/GUIDE.md
+++ b/docs/process/GUIDE.md
@@ -1,0 +1,103 @@
+[< Core](../core/QUICK_START.md) | [Index](../INDEX.md) | [API >](API.md)
+
+# DevToolsKitProcess Guide
+
+Process execution utilities for running external commands with timeout support.
+
+## Setup
+
+Add `DevToolsKitProcess` to your target:
+
+```swift
+.product(name: "DevToolsKitProcess", package: "DevToolsKit")
+```
+
+```swift
+import DevToolsKitProcess
+```
+
+No additional configuration needed — `ProcessExecutor` uses static methods.
+
+## Synchronous Execution
+
+Run a command and wait for it to complete:
+
+```swift
+let result = try ProcessExecutor.execute(
+    "/usr/bin/git",
+    arguments: ["status"],
+    workingDirectory: projectURL
+)
+
+if result.succeeded {
+    print(result.stdout)
+} else {
+    print("Error: \(result.stderr)")
+}
+```
+
+## Async Execution with Timeout
+
+Run a command asynchronously with optional timeout:
+
+```swift
+let result = try await ProcessExecutor.executeAsync(
+    "/usr/bin/swift",
+    arguments: ["build"],
+    workingDirectory: projectURL,
+    timeout: 120  // seconds
+)
+
+print("Build took \(result.duration)s")
+```
+
+If the process exceeds the timeout, it is terminated via `SIGTERM`.
+
+## Shell Commands
+
+Execute shell commands with pipes, redirections, and variables:
+
+```swift
+let result = try await ProcessExecutor.executeShell(
+    "git log --oneline | head -5",
+    workingDirectory: projectURL
+)
+```
+
+Shell commands run via `/bin/bash -c` with a standard `PATH`.
+
+## ProcessResult
+
+Every execution returns a `ProcessResult` with:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `UUID` | Unique identifier |
+| `exitCode` | `Int32` | Process exit code |
+| `stdout` | `String` | Captured standard output |
+| `stderr` | `String` | Captured standard error |
+| `duration` | `TimeInterval` | Execution time in seconds |
+| `startedAt` | `Date` | When execution began |
+| `succeeded` | `Bool` | Whether exit code is `0` |
+
+## Formatting Output
+
+Combine stdout and stderr for display:
+
+```swift
+let output = ProcessExecutor.formatOutput(result)                // stdout + stderr
+let stdoutOnly = ProcessExecutor.formatOutput(result, includeStderr: false)
+```
+
+## Error Handling
+
+`ProcessExecutor` throws `ProcessExecutionError`:
+
+```swift
+do {
+    let result = try ProcessExecutor.execute("/nonexistent/binary")
+} catch let error as ProcessExecutionError {
+    print(error.localizedDescription)
+    // "Process execution failed: ..."
+}
+```


### PR DESCRIPTION
## Summary
- New `DevToolsKitProcess` module with process execution utilities adapted from mlxcoder
- `ProcessExecutor` with sync, async (with timeout), and shell execution
- `ProcessResult` with `Identifiable` conformance, `startedAt` tracking
- `ProcessExecutionError` for typed error handling
- 40 tests, all passing

## Changes
- `Sources/DevToolsKitProcess/` — 3 source files
- `Tests/DevToolsKitProcessTests/` — comprehensive test suite
- `Package.swift` — new product, target, test target
- `docs/process/` — GUIDE.md and API.md
- Updated INDEX.md, README.md, CLAUDE.md

## Test plan
- [x] `swift build` compiles all targets under Swift 6
- [x] `swift test --filter DevToolsKitProcessTests` — 40 tests pass
- [x] All public types have `///` doc comments
- [x] All public types conform to `Sendable`
- [x] No force unwraps, no global mutable state

🤖 Generated with [Claude Code](https://claude.com/claude-code)