### PR TITLE
feat: Add DevToolsKitSecurity module (#11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ Multi-product package:
 - **DevToolsKitLicensingSeat** — LicenseSeat backend (depends on DevToolsKitLicensing + licenseseat-swift)
 - **DevToolsKitLicensingStoreKit** — StoreKit backend (depends on DevToolsKitLicensing)
 - **DevToolsKitProcess** — process execution (no external deps): executor, result, timeout
+- **DevToolsKitSecurity** — security (depends on DevToolsKit): permissions, sandbox, bookmarks, command policy, panel
 
 ## Build & Test
 
@@ -82,6 +83,8 @@ docs/
 ├── licensing/                # DevToolsKitLicensing
 │   ├── API.md, FEATURE_FLAGS.md, EXPERIMENTATION.md, LICENSE_BACKENDS.md
 ├── process/                  # DevToolsKitProcess
+│   ├── API.md, GUIDE.md
+├── security/                 # DevToolsKitSecurity
 │   ├── API.md, GUIDE.md
 ├── TESTING.md, AI_PROMPTS.md, CONTRIBUTING.md
 ```

--- a/Package.swift
+++ b/Package.swift
@@ -36,6 +36,10 @@ let package = Package(
             name: "DevToolsKitProcess",
             targets: ["DevToolsKitProcess"]
         ),
+        .library(
+            name: "DevToolsKitSecurity",
+            targets: ["DevToolsKitSecurity"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.0"),
@@ -104,6 +108,15 @@ let package = Package(
                 .swiftLanguageMode(.v6)
             ]
         ),
+        .target(
+            name: "DevToolsKitSecurity",
+            dependencies: [
+                "DevToolsKit",
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        ),
         .testTarget(
             name: "DevToolsKitTests",
             dependencies: ["DevToolsKit"],
@@ -135,6 +148,13 @@ let package = Package(
         .testTarget(
             name: "DevToolsKitProcessTests",
             dependencies: ["DevToolsKitProcess"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        ),
+        .testTarget(
+            name: "DevToolsKitSecurityTests",
+            dependencies: ["DevToolsKitSecurity"],
             swiftSettings: [
                 .swiftLanguageMode(.v6)
             ]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ DevToolsKit is a modular developer tools framework for macOS SwiftUI apps. Impor
 | **DevToolsKitMetrics** | swift-metrics integration with storage, query, and metrics inspector panel | [swift-metrics](https://github.com/apple/swift-metrics) |
 | **DevToolsKitLicensing** | Feature flags, cohort experiments, percentage rollouts, license-tier gating | [swift-metrics](https://github.com/apple/swift-metrics) |
 | **DevToolsKitProcess** | Process execution with timeout, stdout/stderr capture | None |
+| **DevToolsKitSecurity** | Permissions, sandbox validation, bookmarks, command policy | None |
 
 ## Features
 
@@ -95,6 +96,7 @@ import DevToolsKitLicensing // opt-in
 | LogPanel | Logging | `devtools.log` | ⌘⌥L |
 | MetricsPanel | Metrics | `devtools.metrics` | ⌘⌥I |
 | FeatureFlagsPanel | Licensing | `devtools.feature-flags` | ⌘⌥F |
+| PermissionAuditPanel | Security | `devtools.permissions` | ⌘⌥P |
 
 ## Requirements
 
@@ -127,7 +129,7 @@ Or in Xcode: File > Add Package Dependencies, paste the repository URL.
 
 - **[Documentation Index](docs/INDEX.md)** — All docs, organized by module
 - [Quick Start](docs/core/QUICK_START.md) — Add DevToolsKit to your app in 4 steps
-- [Core API](docs/core/API.md) | [Logging API](docs/logging/API.md) | [Metrics API](docs/metrics/API.md) | [Licensing API](docs/licensing/API.md) | [Process API](docs/process/API.md)
+- [Core API](docs/core/API.md) | [Logging API](docs/logging/API.md) | [Metrics API](docs/metrics/API.md) | [Licensing API](docs/licensing/API.md) | [Process API](docs/process/API.md) | [Security API](docs/security/API.md)
 - [Feature Flags Guide](docs/licensing/FEATURE_FLAGS.md) — Define, gate, and override flags
 - [Testing Patterns](docs/TESTING.md) — Unit testing with DevToolsKit
 - [AI Coding Prompts](docs/AI_PROMPTS.md) — Template prompts for AI assistants

--- a/Sources/DevToolsKitSecurity/Bookmarks/BookmarkManager.swift
+++ b/Sources/DevToolsKitSecurity/Bookmarks/BookmarkManager.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Manages security-scoped bookmarks for persistent file access in sandboxed apps.
+///
+/// Since 0.4.0
+public struct BookmarkManager: Sendable {
+
+    /// Errors related to bookmark operations.
+    public enum BookmarkError: Error, LocalizedError, Sendable {
+        /// Failed to create a security-scoped bookmark.
+        case bookmarkCreationFailed
+        /// Failed to resolve a security-scoped bookmark.
+        case bookmarkResolutionFailed
+        /// Bookmark is stale and needs to be recreated.
+        case bookmarkStale
+
+        public var errorDescription: String? {
+            switch self {
+            case .bookmarkCreationFailed:
+                return "Failed to create security-scoped bookmark"
+            case .bookmarkResolutionFailed:
+                return "Failed to resolve security-scoped bookmark"
+            case .bookmarkStale:
+                return "Bookmark is stale and needs to be recreated"
+            }
+        }
+    }
+
+    /// Creates a new bookmark manager.
+    public init() {}
+
+    /// Create a security-scoped bookmark for a URL.
+    /// - Parameter url: The file URL to bookmark.
+    /// - Returns: Bookmark data that can be persisted.
+    /// - Throws: ``BookmarkError/bookmarkCreationFailed`` if bookmark creation fails.
+    public func createBookmark(for url: URL) throws -> Data {
+        do {
+            return try url.bookmarkData(
+                options: [.withSecurityScope],
+                includingResourceValuesForKeys: nil,
+                relativeTo: nil
+            )
+        } catch {
+            throw BookmarkError.bookmarkCreationFailed
+        }
+    }
+
+    /// Resolve a security-scoped bookmark to access the URL.
+    /// - Parameter bookmarkData: The persisted bookmark data.
+    /// - Returns: Resolved URL and a stop-accessing closure.
+    /// - Throws: ``BookmarkError`` if resolution fails or bookmark is stale.
+    public func resolveBookmark(
+        _ bookmarkData: Data
+    ) throws -> (url: URL, stopAccessing: @Sendable () -> Void) {
+        var isStale = false
+
+        do {
+            let url = try URL(
+                resolvingBookmarkData: bookmarkData,
+                options: [.withSecurityScope, .withoutUI],
+                relativeTo: nil,
+                bookmarkDataIsStale: &isStale
+            )
+
+            if isStale {
+                throw BookmarkError.bookmarkStale
+            }
+
+            guard url.startAccessingSecurityScopedResource() else {
+                throw BookmarkError.bookmarkResolutionFailed
+            }
+
+            return (url, { url.stopAccessingSecurityScopedResource() })
+        } catch {
+            if error is BookmarkError {
+                throw error
+            }
+            throw BookmarkError.bookmarkResolutionFailed
+        }
+    }
+}

--- a/Sources/DevToolsKitSecurity/Core/OperationCategory.swift
+++ b/Sources/DevToolsKitSecurity/Core/OperationCategory.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Categories of operations for permission management.
+///
+/// Provides a configurable mapping from operation names to categories.
+///
+/// Since 0.4.0
+public enum OperationCategory: String, Codable, Sendable, Hashable {
+    /// Read-only operations.
+    case read
+    /// Write operations.
+    case write
+    /// Command execution operations.
+    case execute
+    /// Skill or plugin execution.
+    case skill
+
+    /// Default mapping from operation names to categories.
+    ///
+    /// Maps common names like "read", "glob", "grep" to `.read`,
+    /// "write", "edit" to `.write`, "bash" to `.execute`.
+    /// Unknown names map to `.skill`.
+    public static let defaultMapping: [String: OperationCategory] = [
+        "read": .read,
+        "glob": .read,
+        "grep": .read,
+        "write": .write,
+        "edit": .write,
+        "bash": .execute,
+    ]
+
+    /// Determine the category for a given operation name using the default mapping.
+    /// - Parameter operationName: The name of the operation (case-insensitive).
+    /// - Returns: The category this operation belongs to.
+    public static func category(for operationName: String) -> OperationCategory {
+        category(for: operationName, using: defaultMapping)
+    }
+
+    /// Determine the category for a given operation name using a custom mapping.
+    /// - Parameters:
+    ///   - operationName: The name of the operation (case-insensitive).
+    ///   - mapping: Custom mapping dictionary from operation names to categories.
+    /// - Returns: The category this operation belongs to, or `.skill` if not found.
+    public static func category(
+        for operationName: String,
+        using mapping: [String: OperationCategory]
+    ) -> OperationCategory {
+        mapping[operationName.lowercased()] ?? .skill
+    }
+}

--- a/Sources/DevToolsKitSecurity/Core/PermissionAuditEntry.swift
+++ b/Sources/DevToolsKitSecurity/Core/PermissionAuditEntry.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Audit entry recording a permission decision.
+///
+/// Since 0.4.0
+public struct PermissionAuditEntry: Sendable, Codable, Identifiable {
+    /// Unique identifier.
+    public let id: UUID
+
+    /// Timestamp of the decision.
+    public let timestamp: Date
+
+    /// Name of the operation.
+    public let operationName: String
+
+    /// Category of the operation.
+    public let category: OperationCategory
+
+    /// Configured permission level that was applied.
+    public let configuredLevel: PermissionLevel
+
+    /// Source of the permission configuration.
+    public let source: PermissionSource
+
+    /// User's decision.
+    public let decision: PermissionResponse
+
+    /// Summary of arguments (for debugging).
+    public let argumentsSummary: String
+
+    /// Creates a permission audit entry.
+    /// - Parameters:
+    ///   - id: Unique identifier (defaults to a new UUID).
+    ///   - timestamp: Timestamp of the decision (defaults to now).
+    ///   - operationName: Name of the operation.
+    ///   - category: Category of the operation.
+    ///   - configuredLevel: Configured permission level that was applied.
+    ///   - source: Source of the permission configuration.
+    ///   - decision: User's decision.
+    ///   - argumentsSummary: Summary of arguments.
+    public init(
+        id: UUID = UUID(),
+        timestamp: Date = Date(),
+        operationName: String,
+        category: OperationCategory,
+        configuredLevel: PermissionLevel,
+        source: PermissionSource,
+        decision: PermissionResponse,
+        argumentsSummary: String
+    ) {
+        self.id = id
+        self.timestamp = timestamp
+        self.operationName = operationName
+        self.category = category
+        self.configuredLevel = configuredLevel
+        self.source = source
+        self.decision = decision
+        self.argumentsSummary = argumentsSummary
+    }
+}

--- a/Sources/DevToolsKitSecurity/Core/PermissionConfiguration.swift
+++ b/Sources/DevToolsKitSecurity/Core/PermissionConfiguration.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Configuration for operation permissions.
+///
+/// Permissions are resolved in order: per-operation override, then category default,
+/// then hardcoded defaults.
+///
+/// Since 0.4.0
+public struct PermissionConfiguration: Codable, Sendable, Hashable {
+    /// Per-operation permission overrides (operation name -> permission level).
+    public var perOperation: [String: PermissionLevel]
+
+    /// Per-category default permissions.
+    public var perCategory: [OperationCategory: PermissionLevel]
+
+    /// Creates a permission configuration.
+    /// - Parameters:
+    ///   - perOperation: Per-operation permission overrides.
+    ///   - perCategory: Per-category default permissions.
+    public init(
+        perOperation: [String: PermissionLevel] = [:],
+        perCategory: [OperationCategory: PermissionLevel] = [:]
+    ) {
+        self.perOperation = perOperation
+        self.perCategory = perCategory
+    }
+
+    /// Get the effective permission level for a specific operation.
+    /// - Parameter operationName: The name of the operation.
+    /// - Returns: The effective permission level.
+    public func permission(for operationName: String) -> PermissionLevel {
+        // First check per-operation overrides
+        if let operationPermission = perOperation[operationName] {
+            return operationPermission
+        }
+
+        // Then check category defaults
+        let category = OperationCategory.category(for: operationName)
+        if let categoryPermission = perCategory[category] {
+            return categoryPermission
+        }
+
+        // Fall back to hardcoded defaults
+        return Self.defaultPermissions.perCategory[category] ?? .ask
+    }
+
+    /// Merge this configuration with overrides.
+    /// - Parameter overrides: Configuration to merge on top of this one.
+    /// - Returns: A new configuration with overrides applied.
+    public func merged(with overrides: PermissionConfiguration) -> PermissionConfiguration {
+        var result = self
+
+        for (category, level) in overrides.perCategory {
+            result.perCategory[category] = level
+        }
+
+        for (operation, level) in overrides.perOperation {
+            result.perOperation[operation] = level
+        }
+
+        return result
+    }
+
+    /// Default permissions: read operations allowed, everything else requires approval.
+    public static let defaultPermissions = PermissionConfiguration(
+        perOperation: [:],
+        perCategory: [
+            .read: .allow,
+            .write: .ask,
+            .execute: .ask,
+            .skill: .ask,
+        ]
+    )
+}

--- a/Sources/DevToolsKitSecurity/Core/PermissionHandler.swift
+++ b/Sources/DevToolsKitSecurity/Core/PermissionHandler.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Protocol for handling permission requests.
+///
+/// Implement this protocol to provide custom permission UI or logic.
+///
+/// Since 0.4.0
+public protocol PermissionHandler: Sendable {
+    /// Request permission to execute an operation.
+    /// - Parameter request: The permission request.
+    /// - Returns: The user's response.
+    func requestPermission(_ request: PermissionRequest) async -> PermissionResponse
+}
+
+/// Permission handler that auto-approves all requests.
+///
+/// Useful for testing or trusted environments where all operations should be allowed.
+///
+/// Since 0.4.0
+public struct AutoApprovePermissionHandler: PermissionHandler {
+    /// Creates a new auto-approve handler.
+    public init() {}
+
+    public func requestPermission(_ request: PermissionRequest) async -> PermissionResponse {
+        .allow
+    }
+}

--- a/Sources/DevToolsKitSecurity/Core/PermissionLevel.swift
+++ b/Sources/DevToolsKitSecurity/Core/PermissionLevel.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Permission level for operation execution.
+///
+/// Since 0.4.0
+public enum PermissionLevel: String, Codable, Sendable, Hashable {
+    /// Always allow execution without prompting.
+    case allow
+    /// Ask user for permission before execution.
+    case ask
+    /// Always deny execution.
+    case deny
+}

--- a/Sources/DevToolsKitSecurity/Core/PermissionRequest.swift
+++ b/Sources/DevToolsKitSecurity/Core/PermissionRequest.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Request for permission to execute an operation.
+///
+/// Since 0.4.0
+public struct PermissionRequest: Sendable {
+    /// Name of the operation requesting permission.
+    public let operationName: String
+
+    /// Category of the operation.
+    public let operationCategory: OperationCategory
+
+    /// Arguments passed to the operation.
+    public let arguments: [String: String]
+
+    /// Risk level of this operation.
+    public let riskLevel: RiskLevel
+
+    /// Creates a permission request.
+    /// - Parameters:
+    ///   - operationName: Name of the operation.
+    ///   - operationCategory: Category of the operation.
+    ///   - arguments: Arguments passed to the operation.
+    ///   - riskLevel: Risk level of this operation.
+    public init(
+        operationName: String,
+        operationCategory: OperationCategory,
+        arguments: [String: String],
+        riskLevel: RiskLevel
+    ) {
+        self.operationName = operationName
+        self.operationCategory = operationCategory
+        self.arguments = arguments
+        self.riskLevel = riskLevel
+    }
+}

--- a/Sources/DevToolsKitSecurity/Core/PermissionResponse.swift
+++ b/Sources/DevToolsKitSecurity/Core/PermissionResponse.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Response to a permission request.
+///
+/// Since 0.4.0
+public enum PermissionResponse: Sendable, Codable, Equatable, Hashable {
+    /// Allow this single execution.
+    case allow
+    /// Allow this execution and all future executions of this operation in the current session.
+    case allowForSession
+    /// Deny this execution.
+    case deny
+}

--- a/Sources/DevToolsKitSecurity/Core/PermissionSource.swift
+++ b/Sources/DevToolsKitSecurity/Core/PermissionSource.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Source of a permission configuration.
+///
+/// Since 0.4.0
+public enum PermissionSource: String, Codable, Sendable, Hashable {
+    /// Permission from app-wide defaults.
+    case appDefault
+    /// Permission from project-specific override.
+    case projectOverride
+    /// Permission from session-specific "Allow Always" choice.
+    case sessionOverride
+}

--- a/Sources/DevToolsKitSecurity/Core/RiskLevel.swift
+++ b/Sources/DevToolsKitSecurity/Core/RiskLevel.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Risk level for an operation request.
+///
+/// Since 0.4.0
+public enum RiskLevel: String, Sendable, Codable, Hashable {
+    /// Low risk operation (e.g., reading a single file).
+    case low
+    /// Medium risk operation (e.g., writing to a file).
+    case medium
+    /// High risk operation (e.g., executing shell commands, deleting files).
+    case high
+}

--- a/Sources/DevToolsKitSecurity/Panels/PermissionAuditPanel/PermissionAuditPanel.swift
+++ b/Sources/DevToolsKitSecurity/Panels/PermissionAuditPanel/PermissionAuditPanel.swift
@@ -1,0 +1,33 @@
+import DevToolsKit
+import SwiftUI
+
+/// Panel displaying the permission audit log with filtering.
+///
+/// Since 0.4.0
+public struct PermissionAuditPanel: DevToolPanel {
+    /// Panel identifier.
+    public let id = "devtools.permissions"
+    /// Panel title.
+    public let title = "Permissions"
+    /// SF Symbol icon.
+    public let icon = "lock.shield"
+    /// Keyboard shortcut.
+    public let keyboardShortcut = DevToolsKeyboardShortcut(key: "p")
+    /// Preferred window size.
+    public let preferredSize = CGSize(width: 700, height: 500)
+    /// Minimum window size.
+    public let minimumSize = CGSize(width: 400, height: 300)
+
+    /// The audit store to display.
+    let store: PermissionAuditStore
+
+    /// Creates a permission audit panel.
+    /// - Parameter store: The audit store to display.
+    public init(store: PermissionAuditStore) {
+        self.store = store
+    }
+
+    public func makeBody() -> AnyView {
+        AnyView(PermissionAuditPanelView(store: store))
+    }
+}

--- a/Sources/DevToolsKitSecurity/Panels/PermissionAuditPanel/PermissionAuditPanelView.swift
+++ b/Sources/DevToolsKitSecurity/Panels/PermissionAuditPanel/PermissionAuditPanelView.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+
+/// View displaying the permission audit log.
+@MainActor
+struct PermissionAuditPanelView: View {
+    let store: PermissionAuditStore
+
+    @State private var filterText = ""
+    @State private var filterCategory: OperationCategory?
+
+    private var filteredEntries: [PermissionAuditEntry] {
+        store.entries.filter { entry in
+            if let filterCategory, entry.category != filterCategory {
+                return false
+            }
+            if !filterText.isEmpty {
+                return entry.operationName.localizedCaseInsensitiveContains(filterText)
+                    || entry.argumentsSummary.localizedCaseInsensitiveContains(filterText)
+            }
+            return true
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Toolbar
+            HStack {
+                TextField("Filter...", text: $filterText)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: 200)
+
+                Picker("Category", selection: $filterCategory) {
+                    Text("All").tag(nil as OperationCategory?)
+                    Text("Read").tag(OperationCategory.read as OperationCategory?)
+                    Text("Write").tag(OperationCategory.write as OperationCategory?)
+                    Text("Execute").tag(OperationCategory.execute as OperationCategory?)
+                    Text("Skill").tag(OperationCategory.skill as OperationCategory?)
+                }
+                .pickerStyle(.segmented)
+                .frame(maxWidth: 300)
+
+                Spacer()
+
+                Text("\(filteredEntries.count) entries")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+
+                Button("Clear") {
+                    store.clear()
+                }
+                .buttonStyle(.borderless)
+            }
+            .padding(8)
+
+            Divider()
+
+            // List
+            if filteredEntries.isEmpty {
+                ContentUnavailableView(
+                    "No Audit Entries",
+                    systemImage: "lock.shield",
+                    description: Text("Permission decisions will appear here.")
+                )
+            } else {
+                List(filteredEntries) { entry in
+                    HStack {
+                        decisionIcon(for: entry.decision)
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            HStack {
+                                Text(entry.operationName)
+                                    .font(.body.monospaced())
+                                    .fontWeight(.medium)
+
+                                Text(entry.category.rawValue)
+                                    .font(.caption)
+                                    .padding(.horizontal, 6)
+                                    .padding(.vertical, 2)
+                                    .background(.quaternary)
+                                    .clipShape(Capsule())
+                            }
+
+                            if !entry.argumentsSummary.isEmpty {
+                                Text(entry.argumentsSummary)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+                            }
+                        }
+
+                        Spacer()
+
+                        VStack(alignment: .trailing, spacing: 2) {
+                            Text(entry.source.rawValue)
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+
+                            Text(entry.timestamp, style: .time)
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                        }
+                    }
+                    .padding(.vertical, 2)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func decisionIcon(for decision: PermissionResponse) -> some View {
+        switch decision {
+        case .allow, .allowForSession:
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+        case .deny:
+            Image(systemName: "xmark.circle.fill")
+                .foregroundStyle(.red)
+        }
+    }
+}

--- a/Sources/DevToolsKitSecurity/Panels/PermissionAuditPanel/PermissionAuditStore.swift
+++ b/Sources/DevToolsKitSecurity/Panels/PermissionAuditPanel/PermissionAuditStore.swift
@@ -1,0 +1,35 @@
+import Foundation
+import SwiftUI
+
+/// Observable store for permission audit entries.
+///
+/// Since 0.4.0
+@MainActor
+@Observable
+public final class PermissionAuditStore: Sendable {
+    /// All audit entries, newest first.
+    public private(set) var entries: [PermissionAuditEntry] = []
+
+    /// Maximum number of entries to retain.
+    public let maxEntries: Int
+
+    /// Creates a new audit store.
+    /// - Parameter maxEntries: Maximum number of entries to retain (default: 1000).
+    public init(maxEntries: Int = 1000) {
+        self.maxEntries = maxEntries
+    }
+
+    /// Record a permission decision.
+    /// - Parameter entry: The audit entry to record.
+    public func record(_ entry: PermissionAuditEntry) {
+        entries.insert(entry, at: 0)
+        if entries.count > maxEntries {
+            entries.removeLast()
+        }
+    }
+
+    /// Clear all audit entries.
+    public func clear() {
+        entries.removeAll()
+    }
+}

--- a/Sources/DevToolsKitSecurity/Policy/CommandPolicy.swift
+++ b/Sources/DevToolsKitSecurity/Policy/CommandPolicy.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Security policy for command execution.
+///
+/// Evaluates commands against a set of deny patterns to prevent
+/// execution of dangerous operations.
+///
+/// Since 0.4.0
+public struct CommandPolicy: Codable, Sendable {
+    /// Regex patterns for denied commands.
+    public let deniedPatterns: [String]
+
+    /// Creates a command policy with the given deny patterns.
+    /// - Parameter deniedPatterns: Array of regex patterns for denied commands.
+    public init(deniedPatterns: [String]) {
+        self.deniedPatterns = deniedPatterns
+    }
+
+    /// Check if a command is denied by security policy.
+    /// - Parameter command: The command to check.
+    /// - Returns: A tuple indicating if denied and the reason.
+    public func isDenied(_ command: String) -> (denied: Bool, reason: String?) {
+        for pattern in deniedPatterns {
+            guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else {
+                continue
+            }
+
+            let range = NSRange(command.startIndex..., in: command)
+            if regex.firstMatch(in: command, options: [], range: range) != nil {
+                return (true, "Command matches security deny pattern: \(pattern)")
+            }
+        }
+
+        return (false, nil)
+    }
+
+    /// Default security policy with common dangerous command patterns.
+    public static let `default` = CommandPolicy(deniedPatterns: [
+        // Dangerous file operations
+        #"rm\s+-rf\s+/"#,
+        #"rm\s+-fr\s+/"#,
+        #"rm\s+--recursive\s+--force\s+/"#,
+        #"rm\s+-rf\s+\*"#,
+        #"rm\s+-fr\s+\*"#,
+
+        // Privilege escalation
+        #"^\s*sudo\s+"#,
+        #"^\s*su\s+"#,
+
+        // Fork bombs
+        #":\(\)\{.*:\|:.*\}.*;"#,
+        #"\.\/\.\/\.\/\.\/"#,
+
+        // Dangerous system operations
+        #"mkfs"#,
+        #"dd\s+if=/dev/zero"#,
+        #":\(\)\{.*\}.*\&"#,
+
+        // Network-based attacks
+        #"while\s*:\s*;\s*do.*curl"#,
+        #"while\s*true\s*;\s*do.*wget"#,
+
+        // Kernel operations
+        #"echo\s+.*>\s*/proc/"#,
+        #"echo\s+.*>\s*/sys/"#,
+    ])
+}

--- a/Sources/DevToolsKitSecurity/Sandbox/FileSystemUtility.swift
+++ b/Sources/DevToolsKitSecurity/Sandbox/FileSystemUtility.swift
@@ -1,0 +1,197 @@
+import Foundation
+
+/// Utility for common file system operations.
+///
+/// Provides consistent path resolution, sandbox checking, and backup creation.
+///
+/// Since 0.4.0
+public struct FileSystemUtility: Sendable {
+
+    // MARK: - Path Resolution
+
+    /// Resolves a path (relative or absolute) to an absolute URL.
+    /// - Parameters:
+    ///   - path: The path to resolve (can be relative or absolute).
+    ///   - workingDirectory: The working directory to resolve relative paths against.
+    /// - Returns: An absolute URL.
+    public static func resolveURL(from path: String, workingDirectory: URL) -> URL {
+        if path.hasPrefix("/") {
+            return URL(fileURLWithPath: path)
+        } else {
+            return workingDirectory.appendingPathComponent(path)
+        }
+    }
+
+    /// Standardizes and resolves symlinks in a URL path.
+    ///
+    /// Ensures consistent path comparison, especially for `/var` vs `/private/var` on macOS.
+    /// - Parameter url: The URL to standardize.
+    /// - Returns: A standardized URL with symlinks resolved.
+    public static func standardizeURL(_ url: URL) -> URL {
+        url.standardized.resolvingSymlinksInPath()
+    }
+
+    /// Standardizes and resolves symlinks in a path string.
+    /// - Parameter url: The URL to standardize.
+    /// - Returns: The standardized path string.
+    public static func standardizePath(_ url: URL) -> String {
+        standardizeURL(url).path
+    }
+
+    // MARK: - Sandbox Validation
+
+    /// Checks if a URL is within the allowed paths.
+    ///
+    /// Uses symlink resolution to handle `/var` vs `/private/var` correctly.
+    /// - Parameters:
+    ///   - url: The URL to check.
+    ///   - allowedPaths: Set of allowed directory URLs.
+    /// - Returns: `true` if the URL is within allowed paths.
+    public static func isAllowed(_ url: URL, in allowedPaths: Set<URL>) -> Bool {
+        let normalizedPath = standardizePath(url)
+        return allowedPaths.contains { allowedPath in
+            normalizedPath.hasPrefix(standardizePath(allowedPath))
+        }
+    }
+
+    /// Validates that a path is within allowed directories.
+    /// - Parameters:
+    ///   - path: The path string being validated.
+    ///   - url: The resolved URL to check.
+    ///   - allowedPaths: Set of allowed directory URLs.
+    /// - Throws: ``SandboxError/accessDenied(path:)`` if the path is outside allowed directories.
+    public static func validateSandbox(
+        path: String,
+        url: URL,
+        allowedPaths: Set<URL>
+    ) throws {
+        guard isAllowed(url, in: allowedPaths) else {
+            throw SandboxError.accessDenied(path: path)
+        }
+    }
+
+    /// Standardizes a set of allowed paths for efficient comparison.
+    ///
+    /// Call this once and reuse the result for multiple file checks.
+    /// - Parameter allowedPaths: Set of allowed directory URLs.
+    /// - Returns: Array of standardized path strings.
+    public static func standardizeAllowedPaths(_ allowedPaths: Set<URL>) -> [String] {
+        allowedPaths.map { standardizePath($0) }
+    }
+
+    /// Fast sandbox check using pre-standardized allowed paths.
+    ///
+    /// Use this when checking many files against the same allowed paths.
+    /// - Parameters:
+    ///   - url: The URL to check.
+    ///   - standardizedAllowedPaths: Pre-standardized allowed paths.
+    /// - Returns: `true` if allowed.
+    public static func isAllowed(_ url: URL, in standardizedAllowedPaths: [String]) -> Bool {
+        let normalizedPath = standardizePath(url)
+        return standardizedAllowedPaths.contains { allowedPath in
+            normalizedPath.hasPrefix(allowedPath)
+        }
+    }
+
+    // MARK: - Relative Path Computation
+
+    /// Computes a relative path from a base directory to a file.
+    ///
+    /// Handles symlink resolution to work correctly with `/var` vs `/private/var`.
+    /// - Parameters:
+    ///   - fileURL: The file URL.
+    ///   - baseURL: The base directory URL.
+    /// - Returns: Relative path string, or the filename if paths don't share a common base.
+    public static func relativePath(from fileURL: URL, to baseURL: URL) -> String {
+        let resolvedFilePath = standardizePath(fileURL)
+        let resolvedBasePath = standardizePath(baseURL)
+
+        if resolvedFilePath.hasPrefix(resolvedBasePath) {
+            let relativePath = String(resolvedFilePath.dropFirst(resolvedBasePath.count))
+            if relativePath.hasPrefix("/") {
+                return String(relativePath.dropFirst())
+            }
+            return relativePath.isEmpty ? fileURL.lastPathComponent : relativePath
+        }
+
+        return fileURL.lastPathComponent
+    }
+
+    // MARK: - Backup Creation
+
+    /// Creates a simple backup of a file by copying it with a `.backup` extension.
+    /// - Parameter fileURL: The file to back up.
+    /// - Returns: The backup URL.
+    /// - Throws: FileManager errors if backup creation fails.
+    @discardableResult
+    public static func createSimpleBackup(of fileURL: URL) throws -> URL {
+        let backupURL = fileURL.appendingPathExtension("backup")
+
+        if FileManager.default.fileExists(atPath: backupURL.path) {
+            try FileManager.default.removeItem(at: backupURL)
+        }
+
+        try FileManager.default.copyItem(at: fileURL, to: backupURL)
+        return backupURL
+    }
+
+    /// Creates an archived backup of a file in the temporary directory.
+    ///
+    /// The backup is stored in `/tmp/devtoolskit-backups` with a timestamp.
+    /// - Parameter fileURL: The file to back up.
+    /// - Returns: The backup URL.
+    /// - Throws: FileManager errors if backup creation fails.
+    @discardableResult
+    public static func createArchivedBackup(of fileURL: URL) throws -> URL {
+        let backupDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("devtoolskit-backups")
+
+        if !FileManager.default.fileExists(atPath: backupDir.path) {
+            try FileManager.default.createDirectory(
+                at: backupDir,
+                withIntermediateDirectories: true
+            )
+        }
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        let timestamp = formatter.string(from: Date())
+        let fileName = fileURL.lastPathComponent
+        let backupName = "\(timestamp)_\(fileName)"
+        let backupURL = backupDir.appendingPathComponent(backupName)
+
+        try FileManager.default.copyItem(at: fileURL, to: backupURL)
+        return backupURL
+    }
+
+    // MARK: - File System Checks
+
+    /// Checks if a path exists and is a regular file.
+    /// - Parameter url: The URL to check.
+    /// - Returns: `true` if it exists and is a file.
+    public static func isFile(_ url: URL) -> Bool {
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
+            return false
+        }
+        return !isDirectory.boolValue
+    }
+
+    /// Checks if a path exists and is a directory.
+    /// - Parameter url: The URL to check.
+    /// - Returns: `true` if it exists and is a directory.
+    public static func isDirectory(_ url: URL) -> Bool {
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
+            return false
+        }
+        return isDirectory.boolValue
+    }
+
+    /// Checks if a path exists (file or directory).
+    /// - Parameter url: The URL to check.
+    /// - Returns: `true` if it exists.
+    public static func exists(_ url: URL) -> Bool {
+        FileManager.default.fileExists(atPath: url.path)
+    }
+}

--- a/Sources/DevToolsKitSecurity/Sandbox/SandboxError.swift
+++ b/Sources/DevToolsKitSecurity/Sandbox/SandboxError.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Errors related to sandbox validation.
+///
+/// Since 0.4.0
+public enum SandboxError: Error, LocalizedError, Sendable {
+    /// The path is outside the allowed directories.
+    case accessDenied(path: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .accessDenied(let path):
+            return "Access denied: Path '\(path)' is outside allowed directories"
+        }
+    }
+}

--- a/Tests/DevToolsKitSecurityTests/CommandPolicyTests.swift
+++ b/Tests/DevToolsKitSecurityTests/CommandPolicyTests.swift
@@ -1,0 +1,60 @@
+import Testing
+import Foundation
+@testable import DevToolsKitSecurity
+
+@Suite("CommandPolicy")
+struct CommandPolicyTests {
+
+    @Test func deniesDangerousCommands() {
+        let policy = CommandPolicy.default
+
+        let dangerousCommands = [
+            "rm -rf /",
+            "sudo apt-get install",
+            ":(){ :|: & };:",
+            "mkfs /dev/sda1",
+            "dd if=/dev/zero of=/dev/sda",
+        ]
+
+        for command in dangerousCommands {
+            let result = policy.isDenied(command)
+            #expect(result.denied, "Command should be denied: \(command)")
+            #expect(result.reason != nil)
+        }
+    }
+
+    @Test func allowsSafeCommands() {
+        let policy = CommandPolicy.default
+
+        let safeCommands = [
+            "ls -la",
+            "git status",
+            "swift build",
+            "cat README.md",
+            "echo 'hello world'",
+        ]
+
+        for command in safeCommands {
+            let result = policy.isDenied(command)
+            #expect(!result.denied, "Command should be allowed: \(command)")
+            #expect(result.reason == nil)
+        }
+    }
+
+    @Test func customPolicy() {
+        let policy = CommandPolicy(deniedPatterns: [#"rm\s+"#])
+
+        let result1 = policy.isDenied("rm file.txt")
+        #expect(result1.denied)
+
+        let result2 = policy.isDenied("ls -la")
+        #expect(!result2.denied)
+    }
+
+    @Test func isCodable() throws {
+        let policy = CommandPolicy(deniedPatterns: ["test"])
+        let encoded = try JSONEncoder().encode(policy)
+        let decoded = try JSONDecoder().decode(CommandPolicy.self, from: encoded)
+        #expect(decoded.deniedPatterns == ["test"])
+    }
+}

--- a/Tests/DevToolsKitSecurityTests/FileSystemUtilityTests.swift
+++ b/Tests/DevToolsKitSecurityTests/FileSystemUtilityTests.swift
@@ -1,0 +1,180 @@
+import Testing
+import Foundation
+@testable import DevToolsKitSecurity
+
+@Suite("FileSystemUtility")
+struct FileSystemUtilityTests {
+    let tempDir: URL
+
+    init() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("devtoolskit-fsutil-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    // MARK: - Path Resolution
+
+    @Test func resolveAbsolutePath() {
+        let result = FileSystemUtility.resolveURL(from: "/usr/local/bin/test", workingDirectory: tempDir)
+        #expect(result.path == "/usr/local/bin/test")
+    }
+
+    @Test func resolveRelativePath() {
+        let result = FileSystemUtility.resolveURL(from: "subdir/file.txt", workingDirectory: tempDir)
+        let expected = tempDir.appendingPathComponent("subdir/file.txt")
+        #expect(result.path == expected.path)
+    }
+
+    // MARK: - Standardization
+
+    @Test func standardizeURLRemovesDotComponents() {
+        let url = URL(fileURLWithPath: tempDir.path + "/./subdir/../file.txt")
+        let result = FileSystemUtility.standardizeURL(url)
+        #expect(!result.path.contains("./"))
+        #expect(!result.path.contains("../"))
+    }
+
+    @Test func standardizePathResolvesSymlinks() {
+        let varURL = URL(fileURLWithPath: "/var/tmp")
+        let result = FileSystemUtility.standardizePath(varURL)
+        #expect(result.contains("/tmp"))
+    }
+
+    // MARK: - Sandbox Validation
+
+    @Test func isAllowedWithinSandbox() {
+        let fileURL = tempDir.appendingPathComponent("test.txt")
+        let allowedPaths: Set<URL> = [tempDir]
+        #expect(FileSystemUtility.isAllowed(fileURL, in: allowedPaths))
+    }
+
+    @Test func isAllowedOutsideSandbox() {
+        let fileURL = URL(fileURLWithPath: "/etc/passwd")
+        let allowedPaths: Set<URL> = [tempDir]
+        #expect(!FileSystemUtility.isAllowed(fileURL, in: allowedPaths))
+    }
+
+    @Test func validateSandboxSuccess() throws {
+        let fileURL = tempDir.appendingPathComponent("test.txt")
+        let allowedPaths: Set<URL> = [tempDir]
+        try FileSystemUtility.validateSandbox(path: "test.txt", url: fileURL, allowedPaths: allowedPaths)
+    }
+
+    @Test func validateSandboxFailure() {
+        let fileURL = URL(fileURLWithPath: "/etc/passwd")
+        let allowedPaths: Set<URL> = [tempDir]
+
+        #expect(throws: SandboxError.self) {
+            try FileSystemUtility.validateSandbox(
+                path: "/etc/passwd", url: fileURL, allowedPaths: allowedPaths
+            )
+        }
+    }
+
+    @Test func standardizeAllowedPaths() {
+        let paths: Set<URL> = [tempDir, tempDir.appendingPathComponent("subdir")]
+        let standardized = FileSystemUtility.standardizeAllowedPaths(paths)
+        #expect(standardized.count == 2)
+        for path in standardized {
+            #expect(path.hasPrefix("/"))
+        }
+    }
+
+    @Test func isAllowedWithStandardizedPaths() {
+        let allowedPaths: Set<URL> = [tempDir]
+        let standardizedPaths = FileSystemUtility.standardizeAllowedPaths(allowedPaths)
+        let fileURL = tempDir.appendingPathComponent("test.txt")
+        #expect(FileSystemUtility.isAllowed(fileURL, in: standardizedPaths))
+    }
+
+    // MARK: - Relative Paths
+
+    @Test func relativePathSimple() {
+        let fileURL = tempDir.appendingPathComponent("test.txt")
+        let relativePath = FileSystemUtility.relativePath(from: fileURL, to: tempDir)
+        #expect(relativePath == "test.txt")
+    }
+
+    @Test func relativePathNested() {
+        let fileURL = tempDir.appendingPathComponent("subdir/nested/file.txt")
+        let relativePath = FileSystemUtility.relativePath(from: fileURL, to: tempDir)
+        #expect(relativePath == "subdir/nested/file.txt")
+    }
+
+    @Test func relativePathDifferentBase() {
+        let fileURL = URL(fileURLWithPath: "/usr/local/file.txt")
+        let baseURL = URL(fileURLWithPath: "/etc")
+        let relativePath = FileSystemUtility.relativePath(from: fileURL, to: baseURL)
+        #expect(relativePath == "file.txt")
+    }
+
+    // MARK: - Backups
+
+    @Test func createSimpleBackup() throws {
+        let testFile = tempDir.appendingPathComponent("test.txt")
+        try "original content".write(to: testFile, atomically: true, encoding: .utf8)
+
+        let backupURL = try FileSystemUtility.createSimpleBackup(of: testFile)
+        #expect(FileManager.default.fileExists(atPath: backupURL.path))
+        #expect(backupURL.lastPathComponent == "test.txt.backup")
+
+        let backupContent = try String(contentsOf: backupURL, encoding: .utf8)
+        #expect(backupContent == "original content")
+
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    @Test func createArchivedBackup() throws {
+        let testFile = tempDir.appendingPathComponent("archive-test.txt")
+        try "content to archive".write(to: testFile, atomically: true, encoding: .utf8)
+
+        let backupURL = try FileSystemUtility.createArchivedBackup(of: testFile)
+        #expect(FileManager.default.fileExists(atPath: backupURL.path))
+        #expect(backupURL.path.contains("devtoolskit-backups"))
+
+        let backupContent = try String(contentsOf: backupURL, encoding: .utf8)
+        #expect(backupContent == "content to archive")
+
+        try? FileManager.default.removeItem(at: backupURL)
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    // MARK: - File System Checks
+
+    @Test func isFile() throws {
+        let testFile = tempDir.appendingPathComponent("test.txt")
+        try "test".write(to: testFile, atomically: true, encoding: .utf8)
+
+        #expect(FileSystemUtility.isFile(testFile))
+        #expect(!FileSystemUtility.isFile(tempDir))
+
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    @Test func isDirectory() throws {
+        let subdir = tempDir.appendingPathComponent("subdir")
+        try FileManager.default.createDirectory(at: subdir, withIntermediateDirectories: true)
+
+        #expect(FileSystemUtility.isDirectory(subdir))
+        #expect(FileSystemUtility.isDirectory(tempDir))
+
+        let testFile = tempDir.appendingPathComponent("test.txt")
+        try "test".write(to: testFile, atomically: true, encoding: .utf8)
+        #expect(!FileSystemUtility.isDirectory(testFile))
+
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    @Test func exists() throws {
+        let testFile = tempDir.appendingPathComponent("test.txt")
+        #expect(!FileSystemUtility.exists(testFile))
+
+        try "test".write(to: testFile, atomically: true, encoding: .utf8)
+        #expect(FileSystemUtility.exists(testFile))
+
+        try FileManager.default.removeItem(at: testFile)
+        #expect(!FileSystemUtility.exists(testFile))
+
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+}

--- a/Tests/DevToolsKitSecurityTests/PermissionAuditEntryTests.swift
+++ b/Tests/DevToolsKitSecurityTests/PermissionAuditEntryTests.swift
@@ -1,0 +1,93 @@
+import Testing
+import Foundation
+@testable import DevToolsKitSecurity
+
+@Suite("PermissionAuditEntry")
+struct PermissionAuditEntryTests {
+
+    @Test func isCodable() throws {
+        let entry = PermissionAuditEntry(
+            operationName: "Write",
+            category: .write,
+            configuredLevel: .ask,
+            source: .appDefault,
+            decision: .allow,
+            argumentsSummary: "file: test.txt"
+        )
+
+        let encoded = try JSONEncoder().encode(entry)
+        let decoded = try JSONDecoder().decode(PermissionAuditEntry.self, from: encoded)
+
+        #expect(decoded.operationName == "Write")
+        #expect(decoded.category == .write)
+        #expect(decoded.configuredLevel == .ask)
+        #expect(decoded.source == .appDefault)
+        #expect(decoded.argumentsSummary == "file: test.txt")
+    }
+
+    @Test func hasUniqueIdentifier() {
+        let a = PermissionAuditEntry(
+            operationName: "Read", category: .read, configuredLevel: .allow,
+            source: .appDefault, decision: .allow, argumentsSummary: ""
+        )
+        let b = PermissionAuditEntry(
+            operationName: "Read", category: .read, configuredLevel: .allow,
+            source: .appDefault, decision: .allow, argumentsSummary: ""
+        )
+        #expect(a.id != b.id)
+    }
+}
+
+@Suite("PermissionAuditStore")
+@MainActor
+struct PermissionAuditStoreTests {
+
+    @Test func recordsEntries() {
+        let store = PermissionAuditStore()
+        let entry = PermissionAuditEntry(
+            operationName: "Write", category: .write, configuredLevel: .ask,
+            source: .appDefault, decision: .allow, argumentsSummary: "file: test.txt"
+        )
+        store.record(entry)
+        #expect(store.entries.count == 1)
+        #expect(store.entries.first?.operationName == "Write")
+    }
+
+    @Test func newestFirst() {
+        let store = PermissionAuditStore()
+        let entry1 = PermissionAuditEntry(
+            operationName: "First", category: .read, configuredLevel: .allow,
+            source: .appDefault, decision: .allow, argumentsSummary: ""
+        )
+        let entry2 = PermissionAuditEntry(
+            operationName: "Second", category: .write, configuredLevel: .ask,
+            source: .appDefault, decision: .deny, argumentsSummary: ""
+        )
+        store.record(entry1)
+        store.record(entry2)
+        #expect(store.entries.first?.operationName == "Second")
+    }
+
+    @Test func respectsMaxEntries() {
+        let store = PermissionAuditStore(maxEntries: 3)
+        for i in 0..<5 {
+            let entry = PermissionAuditEntry(
+                operationName: "Op\(i)", category: .read, configuredLevel: .allow,
+                source: .appDefault, decision: .allow, argumentsSummary: ""
+            )
+            store.record(entry)
+        }
+        #expect(store.entries.count == 3)
+    }
+
+    @Test func clearRemovesAll() {
+        let store = PermissionAuditStore()
+        let entry = PermissionAuditEntry(
+            operationName: "Test", category: .read, configuredLevel: .allow,
+            source: .appDefault, decision: .allow, argumentsSummary: ""
+        )
+        store.record(entry)
+        store.clear()
+        #expect(store.entries.isEmpty)
+    }
+}

--- a/Tests/DevToolsKitSecurityTests/PermissionConfigurationTests.swift
+++ b/Tests/DevToolsKitSecurityTests/PermissionConfigurationTests.swift
@@ -1,0 +1,199 @@
+import Testing
+import Foundation
+@testable import DevToolsKitSecurity
+
+@Suite("PermissionConfiguration")
+struct PermissionConfigurationTests {
+
+    @Test func defaultPermissionsHaveCorrectValues() {
+        let defaults = PermissionConfiguration.defaultPermissions
+
+        #expect(defaults.permission(for: "Read") == .allow)
+        #expect(defaults.permission(for: "Glob") == .allow)
+        #expect(defaults.permission(for: "grep") == .allow)
+        #expect(defaults.permission(for: "Write") == .ask)
+        #expect(defaults.permission(for: "Edit") == .ask)
+        #expect(defaults.permission(for: "Bash") == .ask)
+        #expect(defaults.permission(for: "SomeSkill") == .ask)
+    }
+
+    @Test func perOperationOverride() {
+        var config = PermissionConfiguration.defaultPermissions
+        config.perOperation["Read"] = .deny
+
+        #expect(config.permission(for: "Read") == .deny)
+        #expect(config.permission(for: "Glob") == .allow)
+    }
+
+    @Test func categoryFallback() {
+        var config = PermissionConfiguration()
+        config.perCategory[.read] = .allow
+        config.perCategory[.write] = .deny
+
+        #expect(config.permission(for: "Read") == .allow)
+        #expect(config.permission(for: "Write") == .deny)
+    }
+
+    @Test func mergedConfigAppliesOverrides() {
+        var base = PermissionConfiguration()
+        base.perCategory[.read] = .allow
+        base.perCategory[.write] = .ask
+        base.perOperation["Read"] = .deny
+
+        var override = PermissionConfiguration()
+        override.perCategory[.write] = .deny
+        override.perOperation["Write"] = .allow
+
+        let merged = base.merged(with: override)
+
+        #expect(merged.perCategory[.read] == .allow)
+        #expect(merged.perCategory[.write] == .deny)
+        #expect(merged.perOperation["Read"] == .deny)
+        #expect(merged.perOperation["Write"] == .allow)
+    }
+
+    @Test func isCodable() throws {
+        var config = PermissionConfiguration()
+        config.perOperation["Read"] = .allow
+        config.perCategory[.write] = .deny
+
+        let encoded = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(PermissionConfiguration.self, from: encoded)
+
+        #expect(decoded.perOperation["Read"] == .allow)
+        #expect(decoded.perCategory[.write] == .deny)
+    }
+
+    @Test func emptyOverridePreservesConfig() {
+        var appConfig = PermissionConfiguration()
+        appConfig.perOperation["Read"] = .allow
+        appConfig.perCategory[.write] = .ask
+
+        let emptyOverride = PermissionConfiguration()
+        let merged = appConfig.merged(with: emptyOverride)
+
+        #expect(merged.permission(for: "Read") == .allow)
+        #expect(merged.permission(for: "Write") == .ask)
+    }
+
+    @Test func projectOverrideWins() {
+        var appConfig = PermissionConfiguration()
+        appConfig.perOperation["Read"] = .allow
+        appConfig.perOperation["Write"] = .ask
+        appConfig.perOperation["Bash"] = .ask
+
+        var projectOverride = PermissionConfiguration()
+        projectOverride.perOperation["Write"] = .deny
+        projectOverride.perOperation["Bash"] = .allow
+
+        let merged = appConfig.merged(with: projectOverride)
+
+        #expect(merged.permission(for: "Read") == .allow)
+        #expect(merged.permission(for: "Write") == .deny)
+        #expect(merged.permission(for: "Bash") == .allow)
+    }
+}
+
+@Suite("OperationCategory")
+struct OperationCategoryTests {
+
+    @Test func defaultMappingHandlesAllKnownOperations() {
+        #expect(OperationCategory.category(for: "Read") == .read)
+        #expect(OperationCategory.category(for: "Glob") == .read)
+        #expect(OperationCategory.category(for: "grep") == .read)
+        #expect(OperationCategory.category(for: "Write") == .write)
+        #expect(OperationCategory.category(for: "Edit") == .write)
+        #expect(OperationCategory.category(for: "Bash") == .execute)
+        #expect(OperationCategory.category(for: "MySkill") == .skill)
+    }
+
+    @Test func caseInsensitiveMapping() {
+        #expect(OperationCategory.category(for: "GREP") == .read)
+        #expect(OperationCategory.category(for: "GrEp") == .read)
+        #expect(OperationCategory.category(for: "bash") == .execute)
+    }
+
+    @Test func customMapping() {
+        let custom: [String: OperationCategory] = [
+            "fetch": .read,
+            "deploy": .execute,
+        ]
+        #expect(OperationCategory.category(for: "fetch", using: custom) == .read)
+        #expect(OperationCategory.category(for: "deploy", using: custom) == .execute)
+        #expect(OperationCategory.category(for: "unknown", using: custom) == .skill)
+    }
+
+    @Test func isCodable() throws {
+        let category: OperationCategory = .read
+        let encoded = try JSONEncoder().encode(category)
+        let decoded = try JSONDecoder().decode(OperationCategory.self, from: encoded)
+        #expect(decoded == .read)
+    }
+}
+
+@Suite("PermissionLevel")
+struct PermissionLevelTests {
+
+    @Test func isCodable() throws {
+        let level: PermissionLevel = .ask
+        let encoded = try JSONEncoder().encode(level)
+        let decoded = try JSONDecoder().decode(PermissionLevel.self, from: encoded)
+        #expect(decoded == .ask)
+    }
+}
+
+@Suite("PermissionResponse")
+struct PermissionResponseTests {
+
+    @Test func equality() {
+        #expect(PermissionResponse.allow == .allow)
+        #expect(PermissionResponse.deny == .deny)
+        #expect(PermissionResponse.allowForSession == .allowForSession)
+        #expect(PermissionResponse.allow != .deny)
+    }
+
+    @Test func isCodable() throws {
+        let response: PermissionResponse = .allowForSession
+        let encoded = try JSONEncoder().encode(response)
+        let decoded = try JSONDecoder().decode(PermissionResponse.self, from: encoded)
+        #expect(decoded == .allowForSession)
+    }
+}
+
+@Suite("RiskLevel")
+struct RiskLevelTests {
+
+    @Test func isCodable() throws {
+        let risk: RiskLevel = .high
+        let encoded = try JSONEncoder().encode(risk)
+        let decoded = try JSONDecoder().decode(RiskLevel.self, from: encoded)
+        #expect(decoded == .high)
+    }
+}
+
+@Suite("PermissionSource")
+struct PermissionSourceTests {
+
+    @Test func isCodable() throws {
+        let source: PermissionSource = .projectOverride
+        let encoded = try JSONEncoder().encode(source)
+        let decoded = try JSONDecoder().decode(PermissionSource.self, from: encoded)
+        #expect(decoded == .projectOverride)
+    }
+}
+
+@Suite("AutoApprovePermissionHandler")
+struct AutoApprovePermissionHandlerTests {
+
+    @Test func alwaysAllows() async {
+        let handler = AutoApprovePermissionHandler()
+        let request = PermissionRequest(
+            operationName: "Write",
+            operationCategory: .write,
+            arguments: ["file": "test.txt"],
+            riskLevel: .medium
+        )
+        let response = await handler.requestPermission(request)
+        #expect(response == .allow)
+    }
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -13,6 +13,7 @@ DevToolsKit is a multi-product Swift package. Import only what you need.
 | **[DevToolsKitMetrics](metrics/GUIDE.md)** | swift-metrics integration with storage, query, and metrics inspector panel | DevToolsKit, [swift-metrics](https://github.com/apple/swift-metrics) |
 | **[DevToolsKitLicensing](licensing/FEATURE_FLAGS.md)** | Feature flags, experimentation (cohorts/rollouts), license gating | DevToolsKit, [swift-metrics](https://github.com/apple/swift-metrics) |
 | **[DevToolsKitProcess](process/GUIDE.md)** | Process execution with timeout, stdout/stderr capture | None |
+| **[DevToolsKitSecurity](security/GUIDE.md)** | Permissions, sandbox validation, bookmarks, command policy | DevToolsKit |
 
 ## Quick Links
 
@@ -43,6 +44,10 @@ DevToolsKit is a multi-product Swift package. Import only what you need.
 ### Process Execution (opt-in)
 - [Process Guide](process/GUIDE.md) — Process execution with timeout and output capture
 - [Process API Reference](process/API.md)
+
+### Security (opt-in)
+- [Security Guide](security/GUIDE.md) — Permissions, sandbox, bookmarks, command policy
+- [Security API Reference](security/API.md)
 
 ### Cross-Module
 - [Testing Patterns](TESTING.md)

--- a/docs/security/API.md
+++ b/docs/security/API.md
@@ -1,0 +1,162 @@
+[< Guide](GUIDE.md) | [Index](../INDEX.md)
+
+# DevToolsKitSecurity API Reference
+
+> Source: `Sources/DevToolsKitSecurity/`
+> Since: 0.4.0
+
+## Core Types
+
+### RiskLevel
+```swift
+public enum RiskLevel: String, Sendable, Codable, Hashable {
+    case low, medium, high
+}
+```
+
+### PermissionLevel
+```swift
+public enum PermissionLevel: String, Codable, Sendable, Hashable {
+    case allow, ask, deny
+}
+```
+
+### OperationCategory
+```swift
+public enum OperationCategory: String, Codable, Sendable, Hashable {
+    case read, write, execute, skill
+
+    public static let defaultMapping: [String: OperationCategory]
+    public static func category(for operationName: String) -> OperationCategory
+    public static func category(for operationName: String, using mapping: [String: OperationCategory]) -> OperationCategory
+}
+```
+
+### PermissionRequest
+```swift
+public struct PermissionRequest: Sendable {
+    public let operationName: String
+    public let operationCategory: OperationCategory
+    public let arguments: [String: String]
+    public let riskLevel: RiskLevel
+}
+```
+
+### PermissionResponse
+```swift
+public enum PermissionResponse: Sendable, Codable, Equatable, Hashable {
+    case allow, allowForSession, deny
+}
+```
+
+### PermissionConfiguration
+```swift
+public struct PermissionConfiguration: Codable, Sendable, Hashable {
+    public var perOperation: [String: PermissionLevel]
+    public var perCategory: [OperationCategory: PermissionLevel]
+
+    public func permission(for operationName: String) -> PermissionLevel
+    public func merged(with overrides: PermissionConfiguration) -> PermissionConfiguration
+    public static let defaultPermissions: PermissionConfiguration
+}
+```
+
+### PermissionHandler
+```swift
+public protocol PermissionHandler: Sendable {
+    func requestPermission(_ request: PermissionRequest) async -> PermissionResponse
+}
+
+public struct AutoApprovePermissionHandler: PermissionHandler
+```
+
+### PermissionAuditEntry
+```swift
+public struct PermissionAuditEntry: Sendable, Codable, Identifiable {
+    public let id: UUID
+    public let timestamp: Date
+    public let operationName: String
+    public let category: OperationCategory
+    public let configuredLevel: PermissionLevel
+    public let source: PermissionSource
+    public let decision: PermissionResponse
+    public let argumentsSummary: String
+}
+```
+
+### PermissionSource
+```swift
+public enum PermissionSource: String, Codable, Sendable, Hashable {
+    case appDefault, projectOverride, sessionOverride
+}
+```
+
+## Policy
+
+### CommandPolicy
+```swift
+public struct CommandPolicy: Codable, Sendable {
+    public let deniedPatterns: [String]
+    public func isDenied(_ command: String) -> (denied: Bool, reason: String?)
+    public static let `default`: CommandPolicy
+}
+```
+
+## Sandbox
+
+### FileSystemUtility
+```swift
+public struct FileSystemUtility: Sendable {
+    public static func resolveURL(from path: String, workingDirectory: URL) -> URL
+    public static func standardizeURL(_ url: URL) -> URL
+    public static func standardizePath(_ url: URL) -> String
+    public static func isAllowed(_ url: URL, in allowedPaths: Set<URL>) -> Bool
+    public static func validateSandbox(path: String, url: URL, allowedPaths: Set<URL>) throws
+    public static func standardizeAllowedPaths(_ allowedPaths: Set<URL>) -> [String]
+    public static func isAllowed(_ url: URL, in standardizedAllowedPaths: [String]) -> Bool
+    public static func relativePath(from fileURL: URL, to baseURL: URL) -> String
+    public static func createSimpleBackup(of fileURL: URL) throws -> URL
+    public static func createArchivedBackup(of fileURL: URL) throws -> URL
+    public static func isFile(_ url: URL) -> Bool
+    public static func isDirectory(_ url: URL) -> Bool
+    public static func exists(_ url: URL) -> Bool
+}
+```
+
+### SandboxError
+```swift
+public enum SandboxError: Error, LocalizedError, Sendable {
+    case accessDenied(path: String)
+}
+```
+
+## Bookmarks
+
+### BookmarkManager
+```swift
+public struct BookmarkManager: Sendable {
+    public func createBookmark(for url: URL) throws -> Data
+    public func resolveBookmark(_ bookmarkData: Data) throws -> (url: URL, stopAccessing: @Sendable () -> Void)
+}
+```
+
+## Panel
+
+### PermissionAuditPanel
+```swift
+public struct PermissionAuditPanel: DevToolPanel {
+    public let id = "devtools.permissions"
+    public init(store: PermissionAuditStore)
+}
+```
+
+### PermissionAuditStore
+```swift
+@MainActor @Observable
+public final class PermissionAuditStore: Sendable {
+    public private(set) var entries: [PermissionAuditEntry]
+    public let maxEntries: Int
+    public func record(_ entry: PermissionAuditEntry)
+    public func clear()
+}
+```

--- a/docs/security/GUIDE.md
+++ b/docs/security/GUIDE.md
@@ -1,0 +1,102 @@
+[< Core](../core/QUICK_START.md) | [Index](../INDEX.md) | [API >](API.md)
+
+# DevToolsKitSecurity Guide
+
+Permission management, sandbox validation, security-scoped bookmarks, and command policy enforcement.
+
+## Setup
+
+```swift
+.product(name: "DevToolsKitSecurity", package: "DevToolsKit")
+```
+
+```swift
+import DevToolsKitSecurity
+```
+
+## Permission Configuration
+
+Define per-operation and per-category permissions:
+
+```swift
+var config = PermissionConfiguration.defaultPermissions
+config.perOperation["Deploy"] = .deny
+config.perCategory[.execute] = .ask
+
+let level = config.permission(for: "Deploy")  // .deny
+let level2 = config.permission(for: "Bash")   // .ask
+```
+
+Merge project overrides on top of app defaults:
+
+```swift
+let effective = appConfig.merged(with: projectOverride)
+```
+
+## Permission Handler
+
+Implement `PermissionHandler` for custom permission UI:
+
+```swift
+struct MyPermissionHandler: PermissionHandler {
+    func requestPermission(_ request: PermissionRequest) async -> PermissionResponse {
+        // Show UI, return .allow / .allowForSession / .deny
+    }
+}
+```
+
+Use `AutoApprovePermissionHandler` for testing or trusted environments.
+
+## Command Policy
+
+Validate commands against security deny patterns:
+
+```swift
+let policy = CommandPolicy.default
+let (denied, reason) = policy.isDenied("rm -rf /")
+// denied: true, reason: "Command matches security deny pattern: ..."
+```
+
+## Sandbox Validation
+
+Check paths against allowed directories:
+
+```swift
+let allowed = FileSystemUtility.isAllowed(fileURL, in: allowedPaths)
+
+// Or throw on violation:
+try FileSystemUtility.validateSandbox(path: path, url: url, allowedPaths: allowedPaths)
+```
+
+## Bookmarks
+
+Persist file access across app launches in sandboxed apps:
+
+```swift
+let manager = BookmarkManager()
+let data = try manager.createBookmark(for: projectURL)
+// Persist `data` to UserDefaults or disk
+
+let (url, stopAccessing) = try manager.resolveBookmark(data)
+defer { stopAccessing() }
+// Use `url`...
+```
+
+## Audit Panel
+
+Register the permission audit panel to view permission decisions:
+
+```swift
+let auditStore = PermissionAuditStore()
+manager.register(PermissionAuditPanel(store: auditStore))
+
+// Record decisions:
+auditStore.record(PermissionAuditEntry(
+    operationName: "Write",
+    category: .write,
+    configuredLevel: .ask,
+    source: .appDefault,
+    decision: .allow,
+    argumentsSummary: "file: config.json"
+))
+```


### PR DESCRIPTION
## Summary
- New `DevToolsKitSecurity` module with permissions, sandbox validation, bookmarks, and command policy
- Generalized naming: `PermissionLevel`, `OperationCategory`, `PermissionConfiguration`
- `CommandPolicy` for dangerous command detection
- `FileSystemUtility` with sandbox validation that throws `SandboxError`
- `BookmarkManager` for security-scoped bookmarks (no singleton)
- `PermissionAuditPanel` (id: `devtools.permissions`) with filterable audit log
- 45 tests, all passing

## Test plan
- [x] `swift build` compiles all targets under Swift 6
- [x] `swift test --filter DevToolsKitSecurityTests` — 45 tests pass
- [x] All public types have `///` doc comments and conform to `Sendable`
- [x] No force unwraps, no global mutable state

🤖 Generated with [Claude Code](https://claude.com/claude-code)