### PR TITLE
feat: Add DevToolsKitDiff module for unified diff parsing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ Multi-product package:
 - **DevToolsKitProcess** — process execution (no external deps): executor, result, timeout
 - **DevToolsKitSecurity** — security (depends on DevToolsKit): permissions, sandbox, bookmarks, command policy, panel
 - **DevToolsKitGitHub** — GitHub API (depends on DevToolsKit): client, cache, retry, types, panel
+- **DevToolsKitDiff** — diff engine (no external deps): unified diff parsing, application, validation
 
 ## Build & Test
 

--- a/Package.swift
+++ b/Package.swift
@@ -44,6 +44,10 @@ let package = Package(
             name: "DevToolsKitGitHub",
             targets: ["DevToolsKitGitHub"]
         ),
+        .library(
+            name: "DevToolsKitDiff",
+            targets: ["DevToolsKitDiff"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.0"),
@@ -130,6 +134,12 @@ let package = Package(
                 .swiftLanguageMode(.v6)
             ]
         ),
+        .target(
+            name: "DevToolsKitDiff",
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        ),
         .testTarget(
             name: "DevToolsKitTests",
             dependencies: ["DevToolsKit"],
@@ -175,6 +185,13 @@ let package = Package(
         .testTarget(
             name: "DevToolsKitGitHubTests",
             dependencies: ["DevToolsKitGitHub"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        ),
+        .testTarget(
+            name: "DevToolsKitDiffTests",
+            dependencies: ["DevToolsKitDiff"],
             swiftSettings: [
                 .swiftLanguageMode(.v6)
             ]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ DevToolsKit is a modular developer tools framework for macOS SwiftUI apps. Impor
 | **DevToolsKitProcess** | Process execution with timeout, stdout/stderr capture | None |
 | **DevToolsKitSecurity** | Permissions, sandbox validation, bookmarks, command policy | None |
 | **DevToolsKitGitHub** | GitHub REST API client with caching, retry, rate limiting | None |
+| **DevToolsKitDiff** | Unified diff parsing, application, and validation | None |
 
 ## Features
 
@@ -131,7 +132,7 @@ Or in Xcode: File > Add Package Dependencies, paste the repository URL.
 
 - **[Documentation Index](docs/INDEX.md)** — All docs, organized by module
 - [Quick Start](docs/core/QUICK_START.md) — Add DevToolsKit to your app in 4 steps
-- [Core API](docs/core/API.md) | [Logging API](docs/logging/API.md) | [Metrics API](docs/metrics/API.md) | [Licensing API](docs/licensing/API.md) | [Process API](docs/process/API.md) | [Security API](docs/security/API.md) | [GitHub API](docs/github/API.md)
+- [Core API](docs/core/API.md) | [Logging API](docs/logging/API.md) | [Metrics API](docs/metrics/API.md) | [Licensing API](docs/licensing/API.md) | [Process API](docs/process/API.md) | [Security API](docs/security/API.md) | [GitHub API](docs/github/API.md) | [Diff API](docs/diff/API.md)
 - [Feature Flags Guide](docs/licensing/FEATURE_FLAGS.md) — Define, gate, and override flags
 - [Testing Patterns](docs/TESTING.md) — Unit testing with DevToolsKit
 - [AI Coding Prompts](docs/AI_PROMPTS.md) — Template prompts for AI assistants

--- a/Sources/DevToolsKitDiff/DiffEngine.swift
+++ b/Sources/DevToolsKitDiff/DiffEngine.swift
@@ -1,0 +1,280 @@
+import Foundation
+import os
+
+/// Engine for parsing, applying, and validating unified diffs.
+///
+/// `DiffEngine` provides methods to parse unified diff text into structured
+/// ``Diff`` values, apply diffs to files on disk (with backup and dry-run support),
+/// and validate diff structure.
+///
+/// ```swift
+/// let engine = DiffEngine()
+/// let diff = try engine.parse(diffText)
+/// let warnings = engine.validate(diff)
+/// try engine.apply(diff, to: fileURL, dryRun: false)
+/// ```
+///
+/// > Since: 0.4.0
+public struct DiffEngine: Sendable {
+    private static let logger = Logger(
+        subsystem: "com.devtoolskit.diff",
+        category: "DiffEngine"
+    )
+
+    /// Creates a new diff engine.
+    public init() {}
+
+    // MARK: - Parsing
+
+    /// Parses unified diff text into a structured ``Diff``.
+    ///
+    /// The input should be in standard unified diff format with `---`/`+++`
+    /// headers and `@@ ... @@` hunk markers.
+    ///
+    /// - Parameter diffText: The unified diff text to parse.
+    /// - Returns: A parsed ``Diff`` value.
+    /// - Throws: ``DiffError/invalidDiff(_:)`` if the text cannot be parsed.
+    public func parse(_ diffText: String) throws -> Diff {
+        let lines = diffText.split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+
+        guard lines.count >= 2 else {
+            throw DiffError.invalidDiff("Diff too short")
+        }
+
+        // Parse file headers
+        var originalFile = ""
+        var modifiedFile = ""
+        var currentLine = 0
+
+        // Find --- line
+        while currentLine < lines.count {
+            if lines[currentLine].hasPrefix("---") {
+                originalFile = String(
+                    lines[currentLine].dropFirst(4).trimmingCharacters(in: .whitespaces)
+                )
+                currentLine += 1
+                break
+            }
+            currentLine += 1
+        }
+
+        // Find +++ line
+        if currentLine < lines.count && lines[currentLine].hasPrefix("+++") {
+            modifiedFile = String(
+                lines[currentLine].dropFirst(4).trimmingCharacters(in: .whitespaces)
+            )
+            currentLine += 1
+        }
+
+        // Parse hunks
+        var hunks: [Hunk] = []
+
+        while currentLine < lines.count {
+            let line = lines[currentLine]
+
+            if line.hasPrefix("@@") {
+                let hunk = try parseHunk(lines: lines, startIndex: &currentLine)
+                hunks.append(hunk)
+            } else {
+                currentLine += 1
+            }
+        }
+
+        return Diff(originalFile: originalFile, modifiedFile: modifiedFile, hunks: hunks)
+    }
+
+    // MARK: - Application
+
+    /// Applies a diff to a file on disk.
+    ///
+    /// When `dryRun` is `false`, a backup of the original file is created
+    /// before modification. If the write fails, the backup is restored.
+    ///
+    /// - Parameters:
+    ///   - diff: The diff to apply.
+    ///   - fileURL: The file to modify.
+    ///   - dryRun: When `true`, validates that the diff can be applied without modifying the file.
+    /// - Throws: ``DiffError`` if the file cannot be read, the diff cannot be applied,
+    ///   or the modified content cannot be written.
+    public func apply(_ diff: Diff, to fileURL: URL, dryRun: Bool = false) throws {
+        let originalContent: String
+        do {
+            originalContent = try String(contentsOf: fileURL, encoding: .utf8)
+        } catch {
+            throw DiffError.fileReadFailed(fileURL.path)
+        }
+
+        let originalLines = originalContent
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+
+        var modifiedLines = originalLines
+
+        // Apply each hunk in reverse order to preserve line numbers
+        for hunk in diff.hunks.reversed() {
+            modifiedLines = try applyHunk(hunk, to: modifiedLines)
+        }
+
+        let modifiedContent = modifiedLines.joined(separator: "\n")
+
+        if !dryRun {
+            // Create backup
+            let backupURL = fileURL.appendingPathExtension("devtoolskit-diff-backup")
+
+            do {
+                try FileManager.default.copyItem(at: fileURL, to: backupURL)
+            } catch {
+                Self.logger.warning("Could not create backup: \(error.localizedDescription)")
+            }
+
+            do {
+                try modifiedContent.write(to: fileURL, atomically: true, encoding: .utf8)
+                // Remove backup on success
+                try? FileManager.default.removeItem(at: backupURL)
+            } catch {
+                // Restore backup on failure
+                try? FileManager.default.removeItem(at: fileURL)
+                try? FileManager.default.moveItem(at: backupURL, to: fileURL)
+                throw DiffError.fileWriteFailed(fileURL.path)
+            }
+        }
+    }
+
+    /// Applies a diff to in-memory content and returns the result.
+    ///
+    /// - Parameters:
+    ///   - diff: The diff to apply.
+    ///   - content: The original file content.
+    /// - Returns: The modified content after applying all hunks.
+    /// - Throws: ``DiffError/applicationFailed(_:)`` if a hunk cannot be applied.
+    public func apply(_ diff: Diff, to content: String) throws -> String {
+        let originalLines = content
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+
+        var modifiedLines = originalLines
+
+        for hunk in diff.hunks.reversed() {
+            modifiedLines = try applyHunk(hunk, to: modifiedLines)
+        }
+
+        return modifiedLines.joined(separator: "\n")
+    }
+
+    // MARK: - Validation
+
+    /// Validates the structure of a diff and returns any warnings.
+    ///
+    /// - Parameter diff: The diff to validate.
+    /// - Returns: An array of warning messages. An empty array indicates a valid diff.
+    public func validate(_ diff: Diff) -> [String] {
+        var warnings: [String] = []
+
+        if diff.hunks.isEmpty {
+            warnings.append("Diff contains no hunks")
+        }
+
+        for (index, hunk) in diff.hunks.enumerated() {
+            if hunk.originalCount == 0 && hunk.modifiedCount == 0 {
+                warnings.append("Hunk \(index + 1) has zero line counts")
+            }
+
+            if hunk.lines.isEmpty {
+                warnings.append("Hunk \(index + 1) has no lines")
+            }
+        }
+
+        return warnings
+    }
+
+    // MARK: - Private
+
+    private func parseHunk(lines: [String], startIndex: inout Int) throws -> Hunk {
+        let headerLine = lines[startIndex]
+        startIndex += 1
+
+        guard let ranges = headerLine.range(
+            of: #"@@\s*-(\d+),(\d+)\s+\+(\d+),(\d+)\s*@@"#,
+            options: .regularExpression
+        ) else {
+            throw DiffError.invalidDiff("Invalid hunk header: \(headerLine)")
+        }
+
+        let rangeText = String(headerLine[ranges])
+        let numbers = rangeText
+            .components(separatedBy: CharacterSet.decimalDigits.inverted)
+            .compactMap { Int($0) }
+
+        guard numbers.count >= 4 else {
+            throw DiffError.invalidDiff("Could not parse hunk numbers")
+        }
+
+        let originalStart = numbers[0]
+        let originalCount = numbers[1]
+        let modifiedStart = numbers[2]
+        let modifiedCount = numbers[3]
+
+        var hunkLines: [DiffLine] = []
+
+        while startIndex < lines.count {
+            let line = lines[startIndex]
+
+            if line.hasPrefix("@@") {
+                break
+            } else if line.hasPrefix("+") {
+                hunkLines.append(.addition(String(line.dropFirst())))
+                startIndex += 1
+            } else if line.hasPrefix("-") {
+                hunkLines.append(.deletion(String(line.dropFirst())))
+                startIndex += 1
+            } else if line.hasPrefix(" ") || line.isEmpty {
+                hunkLines.append(.context(line.isEmpty ? "" : String(line.dropFirst())))
+                startIndex += 1
+            } else {
+                break
+            }
+        }
+
+        return Hunk(
+            originalStart: originalStart,
+            originalCount: originalCount,
+            modifiedStart: modifiedStart,
+            modifiedCount: modifiedCount,
+            lines: hunkLines
+        )
+    }
+
+    private func applyHunk(_ hunk: Hunk, to lines: [String]) throws -> [String] {
+        var result = lines
+        let startIndex = hunk.originalStart - 1  // Convert to 0-indexed
+
+        guard startIndex >= 0 && startIndex <= result.count else {
+            throw DiffError.applicationFailed(
+                "Hunk start line out of range: \(hunk.originalStart)"
+            )
+        }
+
+        var currentIndex = startIndex
+        for diffLine in hunk.lines {
+            switch diffLine {
+            case .context(let content), .deletion(let content):
+                if currentIndex < result.count && result[currentIndex] != content {
+                    Self.logger.warning("Context mismatch at line \(currentIndex + 1)")
+                }
+                if case .deletion = diffLine {
+                    if currentIndex < result.count {
+                        result.remove(at: currentIndex)
+                    }
+                } else {
+                    currentIndex += 1
+                }
+            case .addition(let content):
+                result.insert(content, at: currentIndex)
+                currentIndex += 1
+            }
+        }
+
+        return result
+    }
+}

--- a/Sources/DevToolsKitDiff/DiffError.swift
+++ b/Sources/DevToolsKitDiff/DiffError.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Errors that can occur during diff parsing or application.
+///
+/// > Since: 0.4.0
+public enum DiffError: Error, LocalizedError, Sendable, Equatable {
+    /// The diff text is malformed or too short to parse.
+    case invalidDiff(String)
+
+    /// A hunk could not be applied to the target file.
+    case applicationFailed(String)
+
+    /// The target file could not be read.
+    case fileReadFailed(String)
+
+    /// The modified content could not be written.
+    case fileWriteFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidDiff(let reason):
+            "Invalid diff: \(reason)"
+        case .applicationFailed(let reason):
+            "Diff application failed: \(reason)"
+        case .fileReadFailed(let reason):
+            "Failed to read file: \(reason)"
+        case .fileWriteFailed(let reason):
+            "Failed to write file: \(reason)"
+        }
+    }
+}

--- a/Sources/DevToolsKitDiff/DiffTypes.swift
+++ b/Sources/DevToolsKitDiff/DiffTypes.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// Represents a complete unified diff between two files.
+///
+/// A `Diff` contains the file paths and one or more `Hunk` values
+/// describing the changes between the original and modified versions.
+///
+/// > Since: 0.4.0
+public struct Diff: Sendable, Equatable {
+    /// Path of the original file (from `---` header).
+    public let originalFile: String
+
+    /// Path of the modified file (from `+++` header).
+    public let modifiedFile: String
+
+    /// The hunks that make up this diff.
+    public let hunks: [Hunk]
+
+    /// Creates a new diff.
+    /// - Parameters:
+    ///   - originalFile: Path of the original file.
+    ///   - modifiedFile: Path of the modified file.
+    ///   - hunks: The hunks describing changes.
+    public init(originalFile: String, modifiedFile: String, hunks: [Hunk]) {
+        self.originalFile = originalFile
+        self.modifiedFile = modifiedFile
+        self.hunks = hunks
+    }
+}
+
+/// Represents a single hunk in a unified diff.
+///
+/// A hunk describes a contiguous region of changes with line ranges
+/// for both the original and modified files.
+///
+/// > Since: 0.4.0
+public struct Hunk: Sendable, Equatable {
+    /// Starting line number in the original file (1-indexed).
+    public let originalStart: Int
+
+    /// Number of lines from the original file in this hunk.
+    public let originalCount: Int
+
+    /// Starting line number in the modified file (1-indexed).
+    public let modifiedStart: Int
+
+    /// Number of lines from the modified file in this hunk.
+    public let modifiedCount: Int
+
+    /// The diff lines that make up this hunk.
+    public let lines: [DiffLine]
+
+    /// Creates a new hunk.
+    /// - Parameters:
+    ///   - originalStart: Starting line in the original file (1-indexed).
+    ///   - originalCount: Number of original lines.
+    ///   - modifiedStart: Starting line in the modified file (1-indexed).
+    ///   - modifiedCount: Number of modified lines.
+    ///   - lines: The diff lines.
+    public init(
+        originalStart: Int,
+        originalCount: Int,
+        modifiedStart: Int,
+        modifiedCount: Int,
+        lines: [DiffLine]
+    ) {
+        self.originalStart = originalStart
+        self.originalCount = originalCount
+        self.modifiedStart = modifiedStart
+        self.modifiedCount = modifiedCount
+        self.lines = lines
+    }
+}
+
+/// Represents a single line in a diff hunk.
+///
+/// > Since: 0.4.0
+public enum DiffLine: Sendable, Equatable {
+    /// A context line (unchanged, prefixed with space in unified diff).
+    case context(String)
+
+    /// An added line (prefixed with `+` in unified diff).
+    case addition(String)
+
+    /// A deleted line (prefixed with `-` in unified diff).
+    case deletion(String)
+
+    /// The text content of this line, without the diff prefix.
+    public var content: String {
+        switch self {
+        case .context(let s), .addition(let s), .deletion(let s):
+            return s
+        }
+    }
+}

--- a/Tests/DevToolsKitDiffTests/DiffEngineTests.swift
+++ b/Tests/DevToolsKitDiffTests/DiffEngineTests.swift
@@ -1,0 +1,351 @@
+import Testing
+import Foundation
+@testable import DevToolsKitDiff
+
+@Suite("DiffTypes")
+struct DiffTypesTests {
+
+    @Test func diffLineContent() {
+        let context = DiffLine.context("hello")
+        let addition = DiffLine.addition("world")
+        let deletion = DiffLine.deletion("removed")
+
+        #expect(context.content == "hello")
+        #expect(addition.content == "world")
+        #expect(deletion.content == "removed")
+    }
+
+    @Test func diffLineEquality() {
+        #expect(DiffLine.context("a") == DiffLine.context("a"))
+        #expect(DiffLine.context("a") != DiffLine.addition("a"))
+        #expect(DiffLine.addition("x") == DiffLine.addition("x"))
+        #expect(DiffLine.deletion("y") == DiffLine.deletion("y"))
+    }
+
+    @Test func diffEquality() {
+        let hunk = Hunk(originalStart: 1, originalCount: 1, modifiedStart: 1, modifiedCount: 1, lines: [.context("a")])
+        let diff1 = Diff(originalFile: "a.txt", modifiedFile: "b.txt", hunks: [hunk])
+        let diff2 = Diff(originalFile: "a.txt", modifiedFile: "b.txt", hunks: [hunk])
+        #expect(diff1 == diff2)
+    }
+
+    @Test func hunkEquality() {
+        let h1 = Hunk(originalStart: 1, originalCount: 2, modifiedStart: 1, modifiedCount: 3, lines: [.addition("x")])
+        let h2 = Hunk(originalStart: 1, originalCount: 2, modifiedStart: 1, modifiedCount: 3, lines: [.addition("x")])
+        #expect(h1 == h2)
+    }
+}
+
+@Suite("DiffError")
+struct DiffErrorTests {
+
+    @Test func errorDescriptions() {
+        let e1 = DiffError.invalidDiff("bad format")
+        let e2 = DiffError.applicationFailed("out of range")
+        let e3 = DiffError.fileReadFailed("/tmp/missing.txt")
+        let e4 = DiffError.fileWriteFailed("/tmp/readonly.txt")
+
+        #expect(e1.errorDescription?.contains("bad format") == true)
+        #expect(e2.errorDescription?.contains("out of range") == true)
+        #expect(e3.errorDescription?.contains("/tmp/missing.txt") == true)
+        #expect(e4.errorDescription?.contains("/tmp/readonly.txt") == true)
+    }
+
+    @Test func equality() {
+        #expect(DiffError.invalidDiff("a") == DiffError.invalidDiff("a"))
+        #expect(DiffError.invalidDiff("a") != DiffError.invalidDiff("b"))
+        #expect(DiffError.invalidDiff("a") != DiffError.applicationFailed("a"))
+    }
+}
+
+@Suite("DiffEngine - Parsing")
+struct DiffEngineParsingTests {
+    let engine = DiffEngine()
+
+    @Test func parseSimpleDiff() throws {
+        let diffText = """
+        --- a/file.txt
+        +++ b/file.txt
+        @@ -1,3 +1,4 @@
+         line1
+        -line2
+        +line2-modified
+        +line2b
+         line3
+        """
+
+        let diff = try engine.parse(diffText)
+        #expect(diff.originalFile == "a/file.txt")
+        #expect(diff.modifiedFile == "b/file.txt")
+        #expect(diff.hunks.count == 1)
+
+        let hunk = diff.hunks[0]
+        #expect(hunk.originalStart == 1)
+        #expect(hunk.originalCount == 3)
+        #expect(hunk.modifiedStart == 1)
+        #expect(hunk.modifiedCount == 4)
+        #expect(hunk.lines.count == 5)
+    }
+
+    @Test func parseMultipleHunks() throws {
+        let diffText = """
+        --- a/file.txt
+        +++ b/file.txt
+        @@ -1,2 +1,2 @@
+        -old1
+        +new1
+         same
+        @@ -10,2 +10,3 @@
+         context
+        -removed
+        +added1
+        +added2
+        """
+
+        let diff = try engine.parse(diffText)
+        #expect(diff.hunks.count == 2)
+        #expect(diff.hunks[0].originalStart == 1)
+        #expect(diff.hunks[1].originalStart == 10)
+    }
+
+    @Test func parseDiffTooShort() {
+        #expect(throws: DiffError.self) {
+            try engine.parse("single line")
+        }
+    }
+
+    @Test func parseInvalidHunkHeader() {
+        let diffText = """
+        --- a/file.txt
+        +++ b/file.txt
+        @@ invalid header @@
+         line
+        """
+
+        #expect(throws: DiffError.self) {
+            try engine.parse(diffText)
+        }
+    }
+
+    @Test func parseAdditionOnly() throws {
+        let diffText = """
+        --- a/file.txt
+        +++ b/file.txt
+        @@ -1,1 +1,3 @@
+         existing
+        +new1
+        +new2
+        """
+
+        let diff = try engine.parse(diffText)
+        let hunk = diff.hunks[0]
+        #expect(hunk.lines.count == 3)
+
+        let additions = hunk.lines.filter { if case .addition = $0 { true } else { false } }
+        #expect(additions.count == 2)
+    }
+
+    @Test func parseDeletionOnly() throws {
+        let diffText = """
+        --- a/file.txt
+        +++ b/file.txt
+        @@ -1,3 +1,1 @@
+         keep
+        -remove1
+        -remove2
+        """
+
+        let diff = try engine.parse(diffText)
+        let hunk = diff.hunks[0]
+        let deletions = hunk.lines.filter { if case .deletion = $0 { true } else { false } }
+        #expect(deletions.count == 2)
+    }
+}
+
+@Suite("DiffEngine - Application")
+struct DiffEngineApplicationTests {
+    let engine = DiffEngine()
+
+    @Test func applyToContent() throws {
+        let original = "line1\nline2\nline3"
+        let diffText = """
+        --- a/file.txt
+        +++ b/file.txt
+        @@ -1,3 +1,3 @@
+         line1
+        -line2
+        +modified
+         line3
+        """
+
+        let diff = try engine.parse(diffText)
+        let result = try engine.apply(diff, to: original)
+        #expect(result == "line1\nmodified\nline3")
+    }
+
+    @Test func applyAddition() throws {
+        let original = "line1\nline2"
+        let diffText = """
+        --- a/file.txt
+        +++ b/file.txt
+        @@ -1,2 +1,3 @@
+         line1
+        +inserted
+         line2
+        """
+
+        let diff = try engine.parse(diffText)
+        let result = try engine.apply(diff, to: original)
+        #expect(result == "line1\ninserted\nline2")
+    }
+
+    @Test func applyDeletion() throws {
+        let original = "line1\nline2\nline3"
+        let diffText = """
+        --- a/file.txt
+        +++ b/file.txt
+        @@ -1,3 +1,2 @@
+         line1
+        -line2
+         line3
+        """
+
+        let diff = try engine.parse(diffText)
+        let result = try engine.apply(diff, to: original)
+        #expect(result == "line1\nline3")
+    }
+
+    @Test func applyToFile() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("devtoolskit-diff-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+        let testFile = tempDir.appendingPathComponent("test.txt")
+        try "line1\nline2\nline3".write(to: testFile, atomically: true, encoding: .utf8)
+
+        let diffText = """
+        --- a/test.txt
+        +++ b/test.txt
+        @@ -1,3 +1,3 @@
+         line1
+        -line2
+        +changed
+         line3
+        """
+
+        let diff = try engine.parse(diffText)
+        try engine.apply(diff, to: testFile, dryRun: false)
+
+        let result = try String(contentsOf: testFile, encoding: .utf8)
+        #expect(result == "line1\nchanged\nline3")
+
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    @Test func dryRunDoesNotModify() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("devtoolskit-diff-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+        let testFile = tempDir.appendingPathComponent("test.txt")
+        let originalContent = "line1\nline2\nline3"
+        try originalContent.write(to: testFile, atomically: true, encoding: .utf8)
+
+        let diffText = """
+        --- a/test.txt
+        +++ b/test.txt
+        @@ -1,3 +1,3 @@
+         line1
+        -line2
+        +changed
+         line3
+        """
+
+        let diff = try engine.parse(diffText)
+        try engine.apply(diff, to: testFile, dryRun: true)
+
+        let result = try String(contentsOf: testFile, encoding: .utf8)
+        #expect(result == originalContent)
+
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    @Test func applyToMissingFile() throws {
+        let diffText = """
+        --- a/file.txt
+        +++ b/file.txt
+        @@ -1,1 +1,1 @@
+        -old
+        +new
+        """
+        let diff = try engine.parse(diffText)
+        let missingURL = URL(fileURLWithPath: "/tmp/devtoolskit-nonexistent-\(UUID().uuidString).txt")
+
+        #expect(throws: DiffError.self) {
+            try engine.apply(diff, to: missingURL)
+        }
+    }
+
+    @Test func applyHunkOutOfRange() throws {
+        let original = "line1"
+        let diffText = """
+        --- a/file.txt
+        +++ b/file.txt
+        @@ -100,1 +100,1 @@
+        -old
+        +new
+        """
+
+        let diff = try engine.parse(diffText)
+        #expect(throws: DiffError.self) {
+            try engine.apply(diff, to: original)
+        }
+    }
+}
+
+@Suite("DiffEngine - Validation")
+struct DiffEngineValidationTests {
+    let engine = DiffEngine()
+
+    @Test func validDiffNoWarnings() throws {
+        let diffText = """
+        --- a/file.txt
+        +++ b/file.txt
+        @@ -1,1 +1,1 @@
+        -old
+        +new
+        """
+
+        let diff = try engine.parse(diffText)
+        let warnings = engine.validate(diff)
+        #expect(warnings.isEmpty)
+    }
+
+    @Test func emptyHunksWarning() {
+        let diff = Diff(originalFile: "a.txt", modifiedFile: "b.txt", hunks: [])
+        let warnings = engine.validate(diff)
+        #expect(warnings.contains { $0.contains("no hunks") })
+    }
+
+    @Test func zeroLineCountsWarning() {
+        let hunk = Hunk(
+            originalStart: 1, originalCount: 0,
+            modifiedStart: 1, modifiedCount: 0,
+            lines: [.context("x")]
+        )
+        let diff = Diff(originalFile: "a.txt", modifiedFile: "b.txt", hunks: [hunk])
+        let warnings = engine.validate(diff)
+        #expect(warnings.contains { $0.contains("zero line counts") })
+    }
+
+    @Test func emptyHunkLinesWarning() {
+        let hunk = Hunk(
+            originalStart: 1, originalCount: 1,
+            modifiedStart: 1, modifiedCount: 1,
+            lines: []
+        )
+        let diff = Diff(originalFile: "a.txt", modifiedFile: "b.txt", hunks: [hunk])
+        let warnings = engine.validate(diff)
+        #expect(warnings.contains { $0.contains("no lines") })
+    }
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -15,6 +15,7 @@ DevToolsKit is a multi-product Swift package. Import only what you need.
 | **[DevToolsKitProcess](process/GUIDE.md)** | Process execution with timeout, stdout/stderr capture | None |
 | **[DevToolsKitSecurity](security/GUIDE.md)** | Permissions, sandbox validation, bookmarks, command policy | DevToolsKit |
 | **[DevToolsKitGitHub](github/GUIDE.md)** | GitHub REST API client with caching, retry, rate limiting | DevToolsKit |
+| **[DevToolsKitDiff](diff/GUIDE.md)** | Unified diff parsing, application, and validation | None |
 
 ## Quick Links
 
@@ -53,6 +54,10 @@ DevToolsKit is a multi-product Swift package. Import only what you need.
 ### GitHub (opt-in)
 - [GitHub Guide](github/GUIDE.md)
 - [GitHub API Reference](github/API.md)
+
+### Diff (opt-in)
+- [Diff Guide](diff/GUIDE.md) — Unified diff parsing, application, and validation
+- [Diff API Reference](diff/API.md)
 
 ### Cross-Module
 - [Testing Patterns](TESTING.md)

--- a/docs/diff/API.md
+++ b/docs/diff/API.md
@@ -1,0 +1,62 @@
+[< Guide](GUIDE.md) | [Index](../INDEX.md)
+
+# DevToolsKitDiff API Reference
+
+> Source: `Sources/DevToolsKitDiff/`
+> Since: 0.4.0
+
+## Types
+
+### Diff
+```swift
+public struct Diff: Sendable, Equatable {
+    public let originalFile: String
+    public let modifiedFile: String
+    public let hunks: [Hunk]
+}
+```
+
+### Hunk
+```swift
+public struct Hunk: Sendable, Equatable {
+    public let originalStart: Int
+    public let originalCount: Int
+    public let modifiedStart: Int
+    public let modifiedCount: Int
+    public let lines: [DiffLine]
+}
+```
+
+### DiffLine
+```swift
+public enum DiffLine: Sendable, Equatable {
+    case context(String)
+    case addition(String)
+    case deletion(String)
+
+    public var content: String
+}
+```
+
+### DiffError
+```swift
+public enum DiffError: Error, LocalizedError, Sendable, Equatable {
+    case invalidDiff(String)
+    case applicationFailed(String)
+    case fileReadFailed(String)
+    case fileWriteFailed(String)
+}
+```
+
+## Engine
+
+### DiffEngine
+```swift
+public struct DiffEngine: Sendable {
+    public init()
+    public func parse(_ diffText: String) throws -> Diff
+    public func apply(_ diff: Diff, to fileURL: URL, dryRun: Bool) throws
+    public func apply(_ diff: Diff, to content: String) throws -> String
+    public func validate(_ diff: Diff) -> [String]
+}
+```

--- a/docs/diff/GUIDE.md
+++ b/docs/diff/GUIDE.md
@@ -1,0 +1,73 @@
+[< GitHub](../github/GUIDE.md) | [Index](../INDEX.md) | [API >](API.md)
+
+# DevToolsKitDiff Guide
+
+Unified diff parsing, application, and validation.
+
+## Setup
+
+```swift
+.product(name: "DevToolsKitDiff", package: "DevToolsKit")
+```
+
+```swift
+import DevToolsKitDiff
+```
+
+## Parsing a Diff
+
+```swift
+let engine = DiffEngine()
+
+let diffText = """
+--- a/file.txt
++++ b/file.txt
+@@ -1,3 +1,3 @@
+ line1
+-line2
++modified
+ line3
+"""
+
+let diff = try engine.parse(diffText)
+// diff.originalFile == "a/file.txt"
+// diff.hunks.count == 1
+```
+
+## Applying to a File
+
+Apply changes to a file on disk with automatic backup:
+
+```swift
+try engine.apply(diff, to: fileURL, dryRun: false)
+```
+
+Use `dryRun: true` to validate without modifying:
+
+```swift
+try engine.apply(diff, to: fileURL, dryRun: true)
+```
+
+## Applying to Content
+
+Apply changes to in-memory content:
+
+```swift
+let original = "line1\nline2\nline3"
+let result = try engine.apply(diff, to: original)
+// result == "line1\nmodified\nline3"
+```
+
+## Validation
+
+Check diff structure for warnings:
+
+```swift
+let warnings = engine.validate(diff)
+// Empty array = valid diff
+```
+
+Warnings include:
+- "Diff contains no hunks"
+- "Hunk N has zero line counts"
+- "Hunk N has no lines"


### PR DESCRIPTION
## Summary

Closes #15

- Adds `DevToolsKitDiff` module with `DiffEngine` for parsing, applying, and validating unified diffs
- `Diff`, `Hunk`, `DiffLine` model types (all `Sendable`, `Equatable`)
- `DiffError` typed error enum for parsing and application failures
- File application with automatic backup/restore and dry-run mode
- In-memory application for content transformation
- 23 tests passing across 5 suites
- Documentation: `docs/diff/GUIDE.md`, `docs/diff/API.md`
- No external dependencies

## Test plan

- [x] `swift build` succeeds
- [x] `swift test --filter DevToolsKitDiff` — 23 tests pass
- [x] All public types are `Sendable`
- [x] All public API has `///` doc comments
- [x] No force unwraps

🤖 Generated with [Claude Code](https://claude.com/claude-code)