### PR TITLE
feat: Add DevToolsKitCodeAnalysisSwift module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,8 @@ Multi-product package:
 - **DevToolsKitSecurity** — security (depends on DevToolsKit): permissions, sandbox, bookmarks, command policy, panel
 - **DevToolsKitGitHub** — GitHub API (depends on DevToolsKit): client, cache, retry, types, panel
 - **DevToolsKitDiff** — diff engine (no external deps): unified diff parsing, application, validation
+- **DevToolsKitCodeAnalysis** — code analysis (depends on DevToolsKit): analyzers, rules, reports, panel
+- **DevToolsKitCodeAnalysisSwift** — Swift analysis (depends on DevToolsKitCodeAnalysis): Swift-specific rules
 - **DevToolsKitCodeAnalysis** — code analysis (depends on DevToolsKit): security, performance, complexity, metrics, reports, panel
 
 ## Build & Test

--- a/Package.swift
+++ b/Package.swift
@@ -52,6 +52,10 @@ let package = Package(
             name: "DevToolsKitCodeAnalysis",
             targets: ["DevToolsKitCodeAnalysis"]
         ),
+        .library(
+            name: "DevToolsKitCodeAnalysisSwift",
+            targets: ["DevToolsKitCodeAnalysisSwift"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.0"),
@@ -151,6 +155,13 @@ let package = Package(
                 .swiftLanguageMode(.v6)
             ]
         ),
+        .target(
+            name: "DevToolsKitCodeAnalysisSwift",
+            dependencies: ["DevToolsKitCodeAnalysis"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        ),
         .testTarget(
             name: "DevToolsKitTests",
             dependencies: ["DevToolsKit"],
@@ -210,6 +221,13 @@ let package = Package(
         .testTarget(
             name: "DevToolsKitCodeAnalysisTests",
             dependencies: ["DevToolsKitCodeAnalysis"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        ),
+        .testTarget(
+            name: "DevToolsKitCodeAnalysisSwiftTests",
+            dependencies: ["DevToolsKitCodeAnalysisSwift", "DevToolsKitCodeAnalysis"],
             swiftSettings: [
                 .swiftLanguageMode(.v6)
             ]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ DevToolsKit is a modular developer tools framework for macOS SwiftUI apps. Impor
 | **DevToolsKitGitHub** | GitHub REST API client with caching, retry, rate limiting | None |
 | **DevToolsKitDiff** | Unified diff parsing, application, and validation | None |
 | **DevToolsKitCodeAnalysis** | Language-agnostic code analysis: security, performance, complexity, metrics, reports | None |
+| **DevToolsKitCodeAnalysisSwift** | Swift-specific analysis rules (force unwraps, retain cycles, etc.) | DevToolsKitCodeAnalysis |
 
 ## Features
 
@@ -134,7 +135,7 @@ Or in Xcode: File > Add Package Dependencies, paste the repository URL.
 
 - **[Documentation Index](docs/INDEX.md)** — All docs, organized by module
 - [Quick Start](docs/core/QUICK_START.md) — Add DevToolsKit to your app in 4 steps
-- [Core API](docs/core/API.md) | [Logging API](docs/logging/API.md) | [Metrics API](docs/metrics/API.md) | [Licensing API](docs/licensing/API.md) | [Process API](docs/process/API.md) | [Security API](docs/security/API.md) | [GitHub API](docs/github/API.md) | [Diff API](docs/diff/API.md) | [Code Analysis API](docs/codeanalysis/API.md)
+- [Core API](docs/core/API.md) | [Logging API](docs/logging/API.md) | [Metrics API](docs/metrics/API.md) | [Licensing API](docs/licensing/API.md) | [Process API](docs/process/API.md) | [Security API](docs/security/API.md) | [GitHub API](docs/github/API.md) | [Diff API](docs/diff/API.md) | [Code Analysis API](docs/codeanalysis/API.md) | [Swift Analysis API](docs/codeanalysis-swift/API.md)
 - [Feature Flags Guide](docs/licensing/FEATURE_FLAGS.md) — Define, gate, and override flags
 - [Testing Patterns](docs/TESTING.md) — Unit testing with DevToolsKit
 - [AI Coding Prompts](docs/AI_PROMPTS.md) — Template prompts for AI assistants

--- a/Sources/DevToolsKitCodeAnalysisSwift/SwiftAnalyzer.swift
+++ b/Sources/DevToolsKitCodeAnalysisSwift/SwiftAnalyzer.swift
@@ -1,0 +1,103 @@
+import Foundation
+import DevToolsKitCodeAnalysis
+
+/// Static analyzer for Swift source files.
+///
+/// `SwiftAnalyzer` implements the ``CodeAnalyzer`` protocol and coordinates
+/// all Swift-specific analysis passes including complexity analysis, code smell
+/// detection, and Swift-specific rules (force unwraps, retain cycles, etc.).
+///
+/// ```swift
+/// let analyzer = SwiftAnalyzer()
+/// let result = try await analyzer.analyze(sourceFile)
+/// print("Found \(result.issues.count) issues")
+/// ```
+///
+/// > Since: 0.4.0
+public struct SwiftAnalyzer: CodeAnalyzer, Sendable {
+
+    /// Creates a new Swift analyzer.
+    public init() {}
+
+    /// Analyze a Swift source file.
+    ///
+    /// Runs complexity analysis, code smell detection, and Swift-specific rules.
+    /// For non-Swift files, returns an empty result with metrics only.
+    ///
+    /// - Parameter file: The source file to analyze.
+    /// - Returns: An ``AnalysisResult`` containing detected issues and metrics.
+    public func analyze(_ file: SourceFile) async throws -> AnalysisResult {
+        let startTime = Date()
+        var allIssues: [Issue] = []
+
+        // Only apply Swift-specific rules to Swift files
+        guard file.language == .swift else {
+            return AnalysisResult(
+                file: file.path,
+                language: file.language,
+                issues: [],
+                metrics: MetricsCalculator.calculate(for: file),
+                duration: Date().timeIntervalSince(startTime)
+            )
+        }
+
+        // Language-agnostic analysis passes (from DevToolsKitCodeAnalysis)
+        allIssues += ComplexityAnalyzer.analyzeCyclomaticComplexity(file)
+        allIssues += ComplexityAnalyzer.analyzeNesting(file)
+
+        allIssues += CodeSmellDetector.detectLongMethods(file)
+        allIssues += CodeSmellDetector.detectLargeTypes(file)
+        allIssues += CodeSmellDetector.detectUnusedVariables(file)
+        allIssues += CodeSmellDetector.detectMagicNumbers(file)
+        allIssues += CodeSmellDetector.detectLongParameterLists(file)
+
+        // Swift-specific analysis passes
+        allIssues += SwiftSpecificRules.detectForceUnwraps(file)
+        allIssues += SwiftSpecificRules.detectImplicitlyUnwrappedOptionals(file)
+        allIssues += SwiftSpecificRules.detectPotentialRetainCycles(file)
+        allIssues += SwiftSpecificRules.detectEmptyCatchBlocks(file)
+        allIssues += SwiftSpecificRules.detectPrintStatements(file)
+        allIssues += SwiftSpecificRules.detectTODOComments(file)
+        allIssues += SwiftSpecificRules.detectForcedTypeCasting(file)
+
+        let metrics = MetricsCalculator.calculate(for: file)
+
+        // Sort by line number, then severity
+        let sortedIssues = allIssues.sorted { lhs, rhs in
+            if lhs.line != rhs.line {
+                return lhs.line < rhs.line
+            }
+            return lhs.severity.priority > rhs.severity.priority
+        }
+
+        let duration = Date().timeIntervalSince(startTime)
+
+        return AnalysisResult(
+            file: file.path,
+            language: file.language,
+            issues: sortedIssues,
+            metrics: metrics,
+            duration: duration
+        )
+    }
+
+    /// Analyze multiple Swift files in batch.
+    ///
+    /// - Parameter files: The source files to analyze.
+    /// - Returns: A ``BatchAnalysisResult`` with results for all files.
+    public static func analyzeBatch(_ files: [SourceFile]) async throws -> BatchAnalysisResult {
+        let startTime = Date()
+        let analyzer = SwiftAnalyzer()
+
+        var results: [AnalysisResult] = []
+
+        for file in files {
+            let result = try await analyzer.analyze(file)
+            results.append(result)
+        }
+
+        let duration = Date().timeIntervalSince(startTime)
+
+        return BatchAnalysisResult(results: results, totalDuration: duration)
+    }
+}

--- a/Sources/DevToolsKitCodeAnalysisSwift/SwiftSpecificRules.swift
+++ b/Sources/DevToolsKitCodeAnalysisSwift/SwiftSpecificRules.swift
@@ -1,0 +1,277 @@
+import Foundation
+import DevToolsKitCodeAnalysis
+
+/// Swift-specific code analysis rules.
+///
+/// Provides detection for common Swift anti-patterns and style issues
+/// including force unwraps, implicitly unwrapped optionals, retain cycles,
+/// empty catch blocks, print statements, TODO/FIXME comments, and forced type casts.
+///
+/// > Since: 0.4.0
+public struct SwiftSpecificRules: Sendable {
+
+    /// Detect force unwraps (`!`) which can cause runtime crashes.
+    ///
+    /// - Parameter file: The source file to analyze.
+    /// - Returns: Issues for each force unwrap found.
+    public static func detectForceUnwraps(_ file: SourceFile) -> [Issue] {
+        var issues: [Issue] = []
+        let lines = file.lines
+
+        guard let forceUnwrapPattern = try? NSRegularExpression(
+            pattern: #"[a-zA-Z0-9_\)]\s*!\s*(?![=:])"#
+        ) else { return issues }
+
+        for (index, line) in lines.enumerated() {
+            let lineNumber = index + 1
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            guard !trimmed.hasPrefix("//") else { continue }
+            guard !trimmed.contains("import ") else { continue }
+
+            let nsLine = line as NSString
+            let matches = forceUnwrapPattern.matches(
+                in: line,
+                range: NSRange(location: 0, length: nsLine.length)
+            )
+
+            for match in matches {
+                issues.append(Issue(
+                    severity: .warning,
+                    category: .style,
+                    line: lineNumber,
+                    column: match.range.location,
+                    message: "Force unwrap (!) detected",
+                    recommendation: "Use optional binding (if let, guard let) or optional chaining (?.) instead of force unwrapping to avoid potential runtime crashes.",
+                    code: "SWIFT-001"
+                ))
+            }
+        }
+
+        return issues
+    }
+
+    /// Detect implicitly unwrapped optionals (`!`) in declarations.
+    ///
+    /// - Parameter file: The source file to analyze.
+    /// - Returns: Issues for each IUO declaration found.
+    public static func detectImplicitlyUnwrappedOptionals(_ file: SourceFile) -> [Issue] {
+        var issues: [Issue] = []
+        let lines = file.lines
+
+        guard let iuoPattern = try? NSRegularExpression(
+            pattern: #"(?:var|let)\s+\w+\s*:\s*\w+\s*!"#
+        ) else { return issues }
+
+        for (index, line) in lines.enumerated() {
+            let lineNumber = index + 1
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            guard !trimmed.hasPrefix("//") else { continue }
+
+            let nsLine = line as NSString
+            let matches = iuoPattern.matches(
+                in: line,
+                range: NSRange(location: 0, length: nsLine.length)
+            )
+
+            for _ in matches {
+                issues.append(Issue(
+                    severity: .info,
+                    category: .style,
+                    line: lineNumber,
+                    message: "Implicitly unwrapped optional detected",
+                    recommendation: "Consider using regular optional (Type?) and proper unwrapping unless there's a specific reason for IUO (e.g., IBOutlets).",
+                    code: "SWIFT-002"
+                ))
+            }
+        }
+
+        return issues
+    }
+
+    /// Detect potential retain cycles in closures that capture `self` without `[weak self]`.
+    ///
+    /// - Parameter file: The source file to analyze.
+    /// - Returns: Issues for each potential retain cycle found.
+    public static func detectPotentialRetainCycles(_ file: SourceFile) -> [Issue] {
+        var issues: [Issue] = []
+        let lines = file.lines
+
+        var inClosure = false
+        var closureStartLine = 0
+        var hasWeakSelf = false
+        var usesSelf = false
+
+        for (index, line) in lines.enumerated() {
+            let lineNumber = index + 1
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            if trimmed.contains("{") && (trimmed.contains(" in") || line.contains("{ [")) {
+                inClosure = true
+                closureStartLine = lineNumber
+                hasWeakSelf = trimmed.contains("[weak self]") || trimmed.contains("[unowned self]")
+                usesSelf = false
+            }
+
+            if inClosure {
+                if trimmed.contains("self.") || trimmed.contains("self?.") {
+                    usesSelf = true
+                }
+
+                if trimmed.contains("}") {
+                    if usesSelf && !hasWeakSelf {
+                        issues.append(Issue(
+                            severity: .warning,
+                            category: .style,
+                            line: closureStartLine,
+                            message: "Potential retain cycle: closure captures 'self' strongly",
+                            recommendation: "Use [weak self] or [unowned self] capture list to avoid retain cycles.",
+                            code: "SWIFT-003"
+                        ))
+                    }
+                    inClosure = false
+                }
+            }
+        }
+
+        return issues
+    }
+
+    /// Detect empty catch blocks that silently swallow errors.
+    ///
+    /// - Parameter file: The source file to analyze.
+    /// - Returns: Issues for each empty catch block found.
+    public static func detectEmptyCatchBlocks(_ file: SourceFile) -> [Issue] {
+        var issues: [Issue] = []
+        let lines = file.lines
+
+        var catchLineNumber: Int?
+        var afterCatch = false
+
+        for (index, line) in lines.enumerated() {
+            let lineNumber = index + 1
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            if trimmed.hasPrefix("catch") || trimmed.contains("} catch") {
+                catchLineNumber = lineNumber
+                afterCatch = true
+                continue
+            }
+
+            if afterCatch {
+                if trimmed == "}" {
+                    if let catchLine = catchLineNumber {
+                        issues.append(Issue(
+                            severity: .warning,
+                            category: .style,
+                            line: catchLine,
+                            message: "Empty catch block",
+                            recommendation: "Handle errors properly or at minimum log them. Silently ignoring errors can hide bugs.",
+                            code: "SWIFT-004"
+                        ))
+                    }
+                    afterCatch = false
+                } else if !trimmed.isEmpty {
+                    afterCatch = false
+                }
+            }
+        }
+
+        return issues
+    }
+
+    /// Detect `print()` statements that should use proper logging in production.
+    ///
+    /// - Parameter file: The source file to analyze.
+    /// - Returns: Issues for each print statement found.
+    public static func detectPrintStatements(_ file: SourceFile) -> [Issue] {
+        var issues: [Issue] = []
+        let lines = file.lines
+
+        for (index, line) in lines.enumerated() {
+            let lineNumber = index + 1
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            guard !trimmed.hasPrefix("//") else { continue }
+
+            if trimmed.contains("print(") || trimmed.hasPrefix("print(") {
+                issues.append(Issue(
+                    severity: .info,
+                    category: .style,
+                    line: lineNumber,
+                    message: "Print statement detected",
+                    recommendation: "Consider using a proper logging framework (e.g., OSLog, SwiftLog) instead of print() for production code.",
+                    code: "SWIFT-005"
+                ))
+            }
+        }
+
+        return issues
+    }
+
+    /// Detect TODO and FIXME comments.
+    ///
+    /// - Parameter file: The source file to analyze.
+    /// - Returns: Issues for each TODO/FIXME comment found.
+    public static func detectTODOComments(_ file: SourceFile) -> [Issue] {
+        var issues: [Issue] = []
+        let lines = file.lines
+
+        for (index, line) in lines.enumerated() {
+            let lineNumber = index + 1
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            if trimmed.contains("TODO:") || trimmed.contains("TODO ") {
+                issues.append(Issue(
+                    severity: .info,
+                    category: .style,
+                    line: lineNumber,
+                    message: "TODO comment found",
+                    recommendation: "Address TODO items before shipping to production."
+                ))
+            }
+
+            if trimmed.contains("FIXME:") || trimmed.contains("FIXME ") {
+                issues.append(Issue(
+                    severity: .warning,
+                    category: .style,
+                    line: lineNumber,
+                    message: "FIXME comment found",
+                    recommendation: "Address FIXME items - they typically indicate known issues that need attention."
+                ))
+            }
+        }
+
+        return issues
+    }
+
+    /// Detect forced type casting (`as!`) which can cause runtime crashes.
+    ///
+    /// - Parameter file: The source file to analyze.
+    /// - Returns: Issues for each forced cast found.
+    public static func detectForcedTypeCasting(_ file: SourceFile) -> [Issue] {
+        var issues: [Issue] = []
+        let lines = file.lines
+
+        for (index, line) in lines.enumerated() {
+            let lineNumber = index + 1
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            guard !trimmed.hasPrefix("//") else { continue }
+
+            if trimmed.contains(" as!") {
+                issues.append(Issue(
+                    severity: .warning,
+                    category: .style,
+                    line: lineNumber,
+                    message: "Forced type cast (as!) detected",
+                    recommendation: "Use optional type casting (as?) with proper error handling instead of forced casting to avoid runtime crashes.",
+                    code: "SWIFT-006"
+                ))
+            }
+        }
+
+        return issues
+    }
+}

--- a/Tests/DevToolsKitCodeAnalysisSwiftTests/SwiftAnalyzerTests.swift
+++ b/Tests/DevToolsKitCodeAnalysisSwiftTests/SwiftAnalyzerTests.swift
@@ -1,0 +1,284 @@
+import Testing
+import Foundation
+@testable import DevToolsKitCodeAnalysis
+@testable import DevToolsKitCodeAnalysisSwift
+
+// MARK: - SwiftSpecificRules Tests
+
+@Suite("SwiftSpecificRules - Force Unwraps")
+struct ForceUnwrapTests {
+
+    @Test func detectsForceUnwrap() {
+        let source = SourceFile(path: "test.swift", content: """
+        let value = optional!
+        let another = dict["key"]!
+        """, language: .swift)
+
+        let issues = SwiftSpecificRules.detectForceUnwraps(source)
+        #expect(issues.count >= 1)
+        #expect(issues.allSatisfy { $0.code == "SWIFT-001" })
+    }
+
+    @Test func ignoresComments() {
+        let source = SourceFile(path: "test.swift", content: """
+        // let value = optional!
+        """, language: .swift)
+
+        let issues = SwiftSpecificRules.detectForceUnwraps(source)
+        #expect(issues.isEmpty)
+    }
+
+    @Test func ignoresImports() {
+        let source = SourceFile(path: "test.swift", content: """
+        import Foundation
+        """, language: .swift)
+
+        let issues = SwiftSpecificRules.detectForceUnwraps(source)
+        #expect(issues.isEmpty)
+    }
+}
+
+@Suite("SwiftSpecificRules - Implicitly Unwrapped Optionals")
+struct IUOTests {
+
+    @Test func detectsIUO() {
+        let source = SourceFile(path: "test.swift", content: """
+        var name: String!
+        let value: Int!
+        """, language: .swift)
+
+        let issues = SwiftSpecificRules.detectImplicitlyUnwrappedOptionals(source)
+        #expect(issues.count == 2)
+        #expect(issues.allSatisfy { $0.code == "SWIFT-002" })
+        #expect(issues.allSatisfy { $0.severity == .info })
+    }
+
+    @Test func ignoresRegularOptionals() {
+        let source = SourceFile(path: "test.swift", content: """
+        var name: String?
+        let value: Int?
+        """, language: .swift)
+
+        let issues = SwiftSpecificRules.detectImplicitlyUnwrappedOptionals(source)
+        #expect(issues.isEmpty)
+    }
+}
+
+@Suite("SwiftSpecificRules - Retain Cycles")
+struct RetainCycleTests {
+
+    @Test func detectsRetainCycle() {
+        let source = SourceFile(path: "test.swift", content: """
+        someFunc { param in
+            self.doSomething()
+        }
+        """, language: .swift)
+
+        let issues = SwiftSpecificRules.detectPotentialRetainCycles(source)
+        #expect(issues.count == 1)
+        #expect(issues[0].code == "SWIFT-003")
+    }
+
+    @Test func noWarningWithWeakSelf() {
+        let source = SourceFile(path: "test.swift", content: """
+        someFunc { [weak self] param in
+            self?.doSomething()
+        }
+        """, language: .swift)
+
+        let issues = SwiftSpecificRules.detectPotentialRetainCycles(source)
+        #expect(issues.isEmpty)
+    }
+
+    @Test func noWarningWithUnownedSelf() {
+        let source = SourceFile(path: "test.swift", content: """
+        someFunc { [unowned self] param in
+            self.doSomething()
+        }
+        """, language: .swift)
+
+        let issues = SwiftSpecificRules.detectPotentialRetainCycles(source)
+        #expect(issues.isEmpty)
+    }
+}
+
+@Suite("SwiftSpecificRules - Empty Catch Blocks")
+struct EmptyCatchTests {
+
+    @Test func detectsEmptyCatch() {
+        let source = SourceFile(path: "test.swift", content: """
+        do {
+            try riskyOperation()
+        } catch {
+        }
+        """, language: .swift)
+
+        let issues = SwiftSpecificRules.detectEmptyCatchBlocks(source)
+        #expect(issues.count == 1)
+        #expect(issues[0].code == "SWIFT-004")
+    }
+
+    @Test func noWarningWithHandledCatch() {
+        let source = SourceFile(path: "test.swift", content: """
+        do {
+            try riskyOperation()
+        } catch {
+            logger.error("Failed: \\(error)")
+        }
+        """, language: .swift)
+
+        let issues = SwiftSpecificRules.detectEmptyCatchBlocks(source)
+        #expect(issues.isEmpty)
+    }
+}
+
+@Suite("SwiftSpecificRules - Print Statements")
+struct PrintStatementTests {
+
+    @Test func detectsPrintStatements() {
+        let source = SourceFile(path: "test.swift", content: """
+        func doWork() {
+            print("Starting work")
+            let result = compute()
+            print("Done: \\(result)")
+        }
+        """, language: .swift)
+
+        let issues = SwiftSpecificRules.detectPrintStatements(source)
+        #expect(issues.count == 2)
+        #expect(issues.allSatisfy { $0.code == "SWIFT-005" })
+        #expect(issues.allSatisfy { $0.severity == .info })
+    }
+
+    @Test func ignoresCommentedPrints() {
+        let source = SourceFile(path: "test.swift", content: """
+        // print("debug")
+        """, language: .swift)
+
+        let issues = SwiftSpecificRules.detectPrintStatements(source)
+        #expect(issues.isEmpty)
+    }
+}
+
+@Suite("SwiftSpecificRules - TODO/FIXME")
+struct TODOTests {
+
+    @Test func detectsTODO() {
+        let source = SourceFile(path: "test.swift", content: """
+        // TODO: Implement this
+        func placeholder() {}
+        """, language: .swift)
+
+        let issues = SwiftSpecificRules.detectTODOComments(source)
+        #expect(issues.count == 1)
+        #expect(issues[0].severity == .info)
+    }
+
+    @Test func detectsFIXME() {
+        let source = SourceFile(path: "test.swift", content: """
+        // FIXME: This is broken
+        func broken() {}
+        """, language: .swift)
+
+        let issues = SwiftSpecificRules.detectTODOComments(source)
+        #expect(issues.count == 1)
+        #expect(issues[0].severity == .warning)
+    }
+}
+
+@Suite("SwiftSpecificRules - Forced Type Casting")
+struct ForcedCastTests {
+
+    @Test func detectsForcedCast() {
+        let source = SourceFile(path: "test.swift", content: """
+        let view = object as! UIView
+        """, language: .swift)
+
+        let issues = SwiftSpecificRules.detectForcedTypeCasting(source)
+        #expect(issues.count == 1)
+        #expect(issues[0].code == "SWIFT-006")
+    }
+
+    @Test func ignoresOptionalCast() {
+        let source = SourceFile(path: "test.swift", content: """
+        let view = object as? UIView
+        """, language: .swift)
+
+        let issues = SwiftSpecificRules.detectForcedTypeCasting(source)
+        #expect(issues.isEmpty)
+    }
+}
+
+// MARK: - SwiftAnalyzer Integration Tests
+
+@Suite("SwiftAnalyzer")
+struct SwiftAnalyzerTests {
+
+    @Test func analyzesSwiftFile() async throws {
+        let analyzer = SwiftAnalyzer()
+        let source = SourceFile(path: "test.swift", content: """
+        import Foundation
+
+        class MyClass {
+            var name: String!  // IUO
+
+            func doWork() {
+                let value = optional!  // force unwrap
+                print("result: \\(value)")  // print statement
+                // TODO: clean this up
+            }
+
+            func riskyStuff() {
+                do {
+                    try something()
+                } catch {
+                }
+            }
+        }
+        """, language: .swift)
+
+        let result = try await analyzer.analyze(source)
+        #expect(result.file == "test.swift")
+        #expect(result.language == .swift)
+        #expect(!result.issues.isEmpty)
+        #expect(result.metrics.linesOfCode > 0)
+    }
+
+    @Test func skipsNonSwiftFiles() async throws {
+        let analyzer = SwiftAnalyzer()
+        let source = SourceFile(path: "test.py", content: """
+        def hello():
+            print("hello")
+        """, language: .python)
+
+        let result = try await analyzer.analyze(source)
+        #expect(result.issues.isEmpty)
+        #expect(result.metrics.linesOfCode > 0)
+    }
+
+    @Test func issuesSortedByLine() async throws {
+        let analyzer = SwiftAnalyzer()
+        let source = SourceFile(path: "test.swift", content: """
+        func test() {
+            print("line 2")
+            let x = optional!
+            print("line 4")
+        }
+        """, language: .swift)
+
+        let result = try await analyzer.analyze(source)
+        let lines = result.issues.map(\.line)
+        #expect(lines == lines.sorted())
+    }
+
+    @Test func batchAnalysis() async throws {
+        let files = [
+            SourceFile(path: "a.swift", content: "let x = value!\n", language: .swift),
+            SourceFile(path: "b.swift", content: "print(\"hello\")\n", language: .swift),
+        ]
+
+        let batch = try await SwiftAnalyzer.analyzeBatch(files)
+        #expect(batch.results.count == 2)
+        #expect(batch.totalDuration >= 0)
+    }
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -17,6 +17,7 @@ DevToolsKit is a multi-product Swift package. Import only what you need.
 | **[DevToolsKitGitHub](github/GUIDE.md)** | GitHub REST API client with caching, retry, rate limiting | DevToolsKit |
 | **[DevToolsKitDiff](diff/GUIDE.md)** | Unified diff parsing, application, and validation | None |
 | **[DevToolsKitCodeAnalysis](codeanalysis/GUIDE.md)** | Language-agnostic code analysis: security, performance, complexity, metrics, reports | DevToolsKit |
+| **[DevToolsKitCodeAnalysisSwift](codeanalysis-swift/GUIDE.md)** | Swift-specific analysis rules | DevToolsKitCodeAnalysis |
 
 ## Quick Links
 
@@ -63,6 +64,10 @@ DevToolsKit is a multi-product Swift package. Import only what you need.
 ### Code Analysis (opt-in)
 - [Code Analysis Guide](codeanalysis/GUIDE.md) — Security, performance, complexity analysis and reporting
 - [Code Analysis API Reference](codeanalysis/API.md)
+
+### Swift Code Analysis (opt-in)
+- [Swift Analysis Guide](codeanalysis-swift/GUIDE.md) — Swift-specific rules
+- [Swift Analysis API Reference](codeanalysis-swift/API.md)
 
 ### Cross-Module
 - [Testing Patterns](TESTING.md)

--- a/docs/codeanalysis-swift/API.md
+++ b/docs/codeanalysis-swift/API.md
@@ -1,0 +1,30 @@
+[< Guide](GUIDE.md) | [Index](../INDEX.md)
+
+# DevToolsKitCodeAnalysisSwift API Reference
+
+> Source: `Sources/DevToolsKitCodeAnalysisSwift/`
+> Since: 0.4.0
+
+## SwiftAnalyzer
+
+```swift
+public struct SwiftAnalyzer: CodeAnalyzer, Sendable {
+    public init()
+    public func analyze(_ file: SourceFile) async throws -> AnalysisResult
+    public static func analyzeBatch(_ files: [SourceFile]) async throws -> BatchAnalysisResult
+}
+```
+
+## SwiftSpecificRules
+
+```swift
+public struct SwiftSpecificRules: Sendable {
+    public static func detectForceUnwraps(_ file: SourceFile) -> [Issue]
+    public static func detectImplicitlyUnwrappedOptionals(_ file: SourceFile) -> [Issue]
+    public static func detectPotentialRetainCycles(_ file: SourceFile) -> [Issue]
+    public static func detectEmptyCatchBlocks(_ file: SourceFile) -> [Issue]
+    public static func detectPrintStatements(_ file: SourceFile) -> [Issue]
+    public static func detectTODOComments(_ file: SourceFile) -> [Issue]
+    public static func detectForcedTypeCasting(_ file: SourceFile) -> [Issue]
+}
+```

--- a/docs/codeanalysis-swift/GUIDE.md
+++ b/docs/codeanalysis-swift/GUIDE.md
@@ -1,0 +1,57 @@
+[< Code Analysis](../codeanalysis/GUIDE.md) | [Index](../INDEX.md) | [API >](API.md)
+
+# DevToolsKitCodeAnalysisSwift Guide
+
+Swift-specific static analysis rules built on top of DevToolsKitCodeAnalysis.
+
+## Setup
+
+```swift
+.product(name: "DevToolsKitCodeAnalysisSwift", package: "DevToolsKit")
+```
+
+```swift
+import DevToolsKitCodeAnalysisSwift
+```
+
+## SwiftAnalyzer
+
+`SwiftAnalyzer` implements `CodeAnalyzer` and runs both language-agnostic rules (complexity, code smells) and Swift-specific rules:
+
+```swift
+let analyzer = SwiftAnalyzer()
+let result = try await analyzer.analyze(sourceFile)
+
+for issue in result.issues {
+    print("\(issue.line): [\(issue.code ?? "")] \(issue.message)")
+}
+```
+
+## Batch Analysis
+
+```swift
+let batch = try await SwiftAnalyzer.analyzeBatch(files)
+print("Total issues: \(batch.totalIssues)")
+```
+
+## Swift-Specific Rules
+
+| Code | Rule | Severity |
+|------|------|----------|
+| SWIFT-001 | Force unwrap (`!`) | Warning |
+| SWIFT-002 | Implicitly unwrapped optional | Info |
+| SWIFT-003 | Potential retain cycle (missing `[weak self]`) | Warning |
+| SWIFT-004 | Empty catch block | Warning |
+| SWIFT-005 | Print statement (use proper logging) | Info |
+| — | TODO comment | Info |
+| — | FIXME comment | Warning |
+| SWIFT-006 | Forced type cast (`as!`) | Warning |
+
+## Using Individual Rules
+
+You can also use `SwiftSpecificRules` methods directly:
+
+```swift
+let issues = SwiftSpecificRules.detectForceUnwraps(sourceFile)
+let retainCycles = SwiftSpecificRules.detectPotentialRetainCycles(sourceFile)
+```


### PR DESCRIPTION
## Summary

Closes #22

- Adds `DevToolsKitCodeAnalysisSwift` module with Swift-specific static analysis rules
- `SwiftAnalyzer` implements `CodeAnalyzer`, coordinates language-agnostic + Swift-specific passes
- `SwiftSpecificRules` with 7 detectors: force unwraps, IUOs, retain cycles, empty catch, print statements, TODO/FIXME, forced casts
- Depends on `DevToolsKitCodeAnalysis` for shared types and language-agnostic rules
- 20 tests passing across 8 suites
- Documentation: `docs/codeanalysis-swift/GUIDE.md`, `docs/codeanalysis-swift/API.md`

## Test plan

- [x] `swift build` succeeds
- [x] `swift test --filter DevToolsKitCodeAnalysisSwift` — 20 tests pass
- [x] All public types are `Sendable`
- [x] All public API has `///` doc comments
- [x] No force unwraps

🤖 Generated with [Claude Code](https://claude.com/claude-code)