### PR TITLE
fix: Wire windowed display mode to open DevToolsTabbedWindow

### DIFF
--- a/Sources/DevToolsKit/Core/DevToolsManager.swift
+++ b/Sources/DevToolsKit/Core/DevToolsManager.swift
@@ -23,6 +23,9 @@ public final class DevToolsManager: Sendable {
     /// Shared window manager for standalone / pop-out windows.
     internal let windowManager = DevToolsWindowManager()
 
+    /// Shared tabbed window for windowed display mode.
+    internal let tabbedWindow = DevToolsTabbedWindow()
+
     // MARK: - Registered Panels
 
     /// All registered panels in registration order.
@@ -211,7 +214,11 @@ public final class DevToolsManager: Sendable {
         case .windowed:
             activeTabbedPanelID = panelID
             isTabbedWindowOpen = true
+            tabbedWindow.open(manager: self)
         case .separateWindows:
+            if let panel = panel(for: panelID) {
+                windowManager.open(panel: panel)
+            }
             openStandalonePanelIDs.insert(panelID)
         }
     }

--- a/Sources/DevToolsKit/Menu/DevToolsCommands.swift
+++ b/Sources/DevToolsKit/Menu/DevToolsCommands.swift
@@ -89,16 +89,6 @@ public struct DevToolsCommands: Commands {
     }
 
     private func openPanel(_ panel: any DevToolPanel) {
-        switch manager.displayMode {
-        case .docked:
-            manager.activeDockPanelID = panel.id
-            manager.isDockVisible = true
-        case .windowed:
-            manager.activeTabbedPanelID = panel.id
-            manager.isTabbedWindowOpen = true
-        case .separateWindows:
-            manager.windowManager.open(panel: panel)
-            manager.openStandalonePanelIDs.insert(panel.id)
-        }
+        manager.openPanel(panel.id)
     }
 }

--- a/docs/core/WINDOW_MODES.md
+++ b/docs/core/WINDOW_MODES.md
@@ -31,11 +31,11 @@ The dock toolbar includes a position picker, pop-out button, and close button. A
 
 ### Windowed (default)
 
-All panels share a single tabbed `NSWindow`. This is the default mode.
+All panels share a single tabbed `NSWindow` managed by `DevToolsManager.tabbedWindow`. This is the default mode. Calling `openPanel` creates the window (or brings it to front if already visible).
 
 ```swift
 manager.displayMode = .windowed
-manager.openPanel("devtools.log")
+manager.openPanel("devtools.log")  // Opens/focuses the tabbed NSWindow
 ```
 
 Open all panels at once with **⌘⌥⇧D** or programmatically:


### PR DESCRIPTION
## Summary

- Add `tabbedWindow` property to `DevToolsManager` and call `tabbedWindow.open(manager:)` in the `.windowed` case of `openPanel`, so the tabbed NSWindow is actually shown
- Move `windowManager.open(panel:)` into `DevToolsManager.openPanel`'s `.separateWindows` case (was only in `DevToolsCommands`)
- Simplify `DevToolsCommands.openPanel` to delegate entirely to `manager.openPanel`, removing duplicated logic

Fixes #25

## Test plan

- [x] `swift build` compiles cleanly
- [x] `swift test` — all 392 tests pass
- [ ] Manual: in a macOS SwiftUI app with `displayMode = .windowed`, selecting a panel from the Developer menu opens the "Developer Tools" NSWindow
- [ ] Manual: "Show All" (⌘⌥⇧D) opens the window once (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)