### PR TITLE
Fix panel layout: empty states fill available space

### DIFF
--- a/Sources/DevToolsKit/Panels/PerformancePanel/PerformancePanelView.swift
+++ b/Sources/DevToolsKit/Panels/PerformancePanel/PerformancePanelView.swift
@@ -21,6 +21,7 @@ public struct PerformancePanelView: View {
                     systemImage: "gauge",
                     description: Text("Run operations to collect performance metrics.")
                 )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 20) {

--- a/Sources/DevToolsKit/Window/DevToolsTabbedWindow.swift
+++ b/Sources/DevToolsKit/Window/DevToolsTabbedWindow.swift
@@ -113,8 +113,10 @@ struct DevToolsTabbedContentView: View {
             let panel = manager.panel(for: activeID)
         {
             panel.makeBody()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if let firstPanel = manager.panels.first {
             firstPanel.makeBody()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .onAppear {
                     manager.activeTabbedPanelID = firstPanel.id
                 }
@@ -124,6 +126,7 @@ struct DevToolsTabbedContentView: View {
                 systemImage: "rectangle.3.group",
                 description: Text("Register panels to see them here.")
             )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 }

--- a/Sources/DevToolsKitCodeAnalysis/Panels/CodeAnalysisPanel/CodeAnalysisPanelView.swift
+++ b/Sources/DevToolsKitCodeAnalysis/Panels/CodeAnalysisPanel/CodeAnalysisPanelView.swift
@@ -23,6 +23,7 @@ struct CodeAnalysisPanelView: View {
                 systemImage: "magnifyingglass.circle",
                 description: Text("Run a code analysis to see results here.")
             )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 

--- a/Sources/DevToolsKitLicensing/Panels/FeatureFlagsPanel/FeatureFlagsPanelView.swift
+++ b/Sources/DevToolsKitLicensing/Panels/FeatureFlagsPanel/FeatureFlagsPanelView.swift
@@ -103,6 +103,7 @@ public struct FeatureFlagsPanelView: View {
                             ? "Register flags with LicensingManager to see them here."
                             : "No flags match your search.")
                 )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 List {
                     ForEach(filtered, id: \.0) { category, states in

--- a/Sources/DevToolsKitLogging/LogPanelView.swift
+++ b/Sources/DevToolsKitLogging/LogPanelView.swift
@@ -46,6 +46,7 @@ public struct LogPanelView: View {
                     systemImage: "doc.text",
                     description: Text("Log entries will appear here when the app generates output.")
                 )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 ScrollViewReader { proxy in
                     List(logStore.filteredEntries) { entry in

--- a/Sources/DevToolsKitMetrics/Panels/MetricsPanel/MetricsLiveView.swift
+++ b/Sources/DevToolsKitMetrics/Panels/MetricsPanel/MetricsLiveView.swift
@@ -35,6 +35,7 @@ struct MetricsLiveView: View {
                     systemImage: "chart.bar",
                     description: Text("Metrics will appear here when the app records data via swift-metrics.")
                 )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 List(selection: $selectedIdentifier) {
                     ForEach(groupedMetrics, id: \.prefix) { group in

--- a/Sources/DevToolsKitMetrics/Panels/MetricsPanel/MetricsQueryView.swift
+++ b/Sources/DevToolsKitMetrics/Panels/MetricsPanel/MetricsQueryView.swift
@@ -65,6 +65,7 @@ struct MetricsQueryView: View {
                     systemImage: "magnifyingglass",
                     description: Text("Run a query to see matching metric entries.")
                 )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 Table(results) {
                     TableColumn("Time") { entry in

--- a/Sources/DevToolsKitMetrics/Panels/MetricsPanel/MetricsReportView.swift
+++ b/Sources/DevToolsKitMetrics/Panels/MetricsPanel/MetricsReportView.swift
@@ -12,6 +12,7 @@ struct MetricsReportView: View {
                     systemImage: "chart.bar.doc.horizontal",
                     description: Text("Metrics summaries will appear here once data is recorded.")
                 )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 Table(summaries) {
                     TableColumn("Label") { summary in

--- a/Sources/DevToolsKitSecurity/Panels/PermissionAuditPanel/PermissionAuditPanelView.swift
+++ b/Sources/DevToolsKitSecurity/Panels/PermissionAuditPanel/PermissionAuditPanelView.swift
@@ -61,6 +61,7 @@ struct PermissionAuditPanelView: View {
                     systemImage: "lock.shield",
                     description: Text("Permission decisions will appear here.")
                 )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 List(filteredEntries) { entry in
                     HStack {


### PR DESCRIPTION
## Summary

- Add `.frame(maxWidth: .infinity, maxHeight: .infinity)` to all `ContentUnavailableView` empty states across 9 files so they fill remaining space instead of collapsing
- Add frame modifier to `panel.makeBody()` calls in `DevToolsTabbedWindow` as a safety net
- Fixes panel headers/toolbars floating with excessive padding when panels show empty states

Closes #27

## Files changed (9)

| File | Fix |
|------|-----|
| `DevToolsTabbedWindow.swift` | Frame on `makeBody()` calls + "No Panels" empty state |
| `LogPanelView.swift` | "No Log Entries" |
| `PerformancePanelView.swift` | "No Performance Data" |
| `MetricsLiveView.swift` | "No Metrics" (left pane) |
| `MetricsQueryView.swift` | "No Results" |
| `MetricsReportView.swift` | "No Metrics to Report" |
| `FeatureFlagsPanelView.swift` | "No Feature Flags" |
| `PermissionAuditPanelView.swift` | "No Audit Entries" |
| `CodeAnalysisPanelView.swift` | "No Analysis Results" |

## Test plan

- [x] `swift build` — all targets compile
- [x] `swift test` — all 392 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)