### PR TITLE
feat: Add copy/export for filtered log entries

### DIFF
--- a/Sources/DevToolsKitLogging/DevToolsLogEntry.swift
+++ b/Sources/DevToolsKitLogging/DevToolsLogEntry.swift
@@ -2,7 +2,7 @@ import DevToolsKit
 import Foundation
 
 /// A single log entry captured by the DevTools log store.
-public struct DevToolsLogEntry: Identifiable, Sendable {
+public struct DevToolsLogEntry: Identifiable, Sendable, Codable {
     /// Unique identifier for this entry.
     public let id: UUID
     /// When the entry was created.

--- a/Sources/DevToolsKitLogging/LogEntryFormatting.swift
+++ b/Sources/DevToolsKitLogging/LogEntryFormatting.swift
@@ -1,0 +1,85 @@
+#if canImport(AppKit)
+import AppKit
+#endif
+#if canImport(UIKit)
+import UIKit
+#endif
+import DevToolsKit
+import Foundation
+
+/// Formatting utilities for log entries — plain text and JSON.
+///
+/// Since 0.6.0
+public enum LogEntryFormatter: Sendable {
+    private static nonisolated(unsafe) let isoFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    /// Three-letter level code matching the log panel badge text.
+    private static func levelCode(_ level: DevToolsLogLevel) -> String {
+        switch level {
+        case .trace: "TRC"
+        case .debug: "DBG"
+        case .info: "INF"
+        case .warning: "WRN"
+        case .error: "ERR"
+        }
+    }
+
+    /// Format a single entry as a human-readable text line.
+    ///
+    /// Format: `"2026-03-12T10:30:45.123Z  INF  [source]  message"`
+    /// with metadata on a continuation line if present.
+    ///
+    /// - Parameter entry: The log entry to format.
+    /// - Returns: A formatted text representation.
+    public static func formatLine(_ entry: DevToolsLogEntry) -> String {
+        let ts = isoFormatter.string(from: entry.timestamp)
+        let lvl = levelCode(entry.level)
+        var line = "\(ts)  \(lvl)  [\(entry.source)]  \(entry.message)"
+        if let metadata = entry.metadata {
+            line += "\n                              \(metadata)"
+        }
+        return line
+    }
+
+    /// Format multiple entries as newline-separated text.
+    ///
+    /// - Parameter entries: The entries to format.
+    /// - Returns: All entries joined by newlines, or empty string if none.
+    public static func formatText(_ entries: [DevToolsLogEntry]) -> String {
+        entries.map { formatLine($0) }.joined(separator: "\n")
+    }
+
+    /// Encode entries as a pretty-printed JSON array.
+    ///
+    /// - Parameter entries: The entries to encode.
+    /// - Returns: UTF-8 JSON string.
+    /// - Throws: If encoding fails.
+    public static func formatJSON(_ entries: [DevToolsLogEntry]) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(entries)
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    /// Copy text to the system clipboard.
+    ///
+    /// Available on macOS and iOS; unavailable on tvOS and watchOS.
+    ///
+    /// - Parameter text: The string to place on the clipboard.
+    #if !os(tvOS) && !os(watchOS)
+    @MainActor
+    public static func copyToClipboard(_ text: String) {
+        #if canImport(AppKit)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+        #elseif canImport(UIKit)
+        UIPasteboard.general.string = text
+        #endif
+    }
+    #endif
+}

--- a/Sources/DevToolsKitLogging/LogExportDocument.swift
+++ b/Sources/DevToolsKitLogging/LogExportDocument.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// Export format for log entries.
+///
+/// Since 0.6.0
+public enum LogExportFormat: Sendable {
+    /// Plain text, one entry per line.
+    case plainText
+    /// Pretty-printed JSON array.
+    case json
+}
+
+/// A `FileDocument` wrapping formatted log entries for use with `.fileExporter()`.
+///
+/// Since 0.6.0
+public struct LogExportDocument: FileDocument {
+    public static var readableContentTypes: [UTType] { [.plainText, .json] }
+
+    private let content: String
+    private let format: LogExportFormat
+
+    /// Create an export document from log entries.
+    ///
+    /// - Parameters:
+    ///   - entries: The log entries to export.
+    ///   - format: The export format.
+    public init(entries: [DevToolsLogEntry], format: LogExportFormat) {
+        self.format = format
+        switch format {
+        case .plainText:
+            self.content = LogEntryFormatter.formatText(entries)
+        case .json:
+            self.content = (try? LogEntryFormatter.formatJSON(entries)) ?? "[]"
+        }
+    }
+
+    public init(configuration: ReadConfiguration) throws {
+        self.format = .plainText
+        guard let data = configuration.file.regularFileContents else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        self.content = String(decoding: data, as: UTF8.self)
+    }
+
+    public func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
+        guard let data = content.data(using: .utf8) else {
+            throw CocoaError(.fileWriteInapplicableStringEncoding)
+        }
+        return FileWrapper(regularFileWithContents: data)
+    }
+
+    /// The UTType for this document's format.
+    public var contentType: UTType {
+        switch format {
+        case .plainText: .plainText
+        case .json: .json
+        }
+    }
+}

--- a/Sources/DevToolsKitLogging/LogPanelView.swift
+++ b/Sources/DevToolsKitLogging/LogPanelView.swift
@@ -3,6 +3,7 @@ import AppKit
 #endif
 import DevToolsKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// Log viewer UI showing aggregated, filterable log entries with resizable columns.
 public struct LogPanelView: View {
@@ -11,6 +12,10 @@ public struct LogPanelView: View {
     @State private var timestampWidth: CGFloat
     @State private var levelWidth: CGFloat
     @State private var sourceWidth: CGFloat
+    @State private var isExporting = false
+    @State private var exportDocument: LogExportDocument?
+    @State private var exportContentType: UTType = .plainText
+    @State private var copyBounce: Int = 0
 
     private let keyPrefix: String
 
@@ -61,6 +66,22 @@ public struct LogPanelView: View {
                         .listRowSeparator(.hidden)
                         .listRowInsets(EdgeInsets(top: 2, leading: 8, bottom: 2, trailing: 8))
                         .id(entry.id)
+                        #if !os(tvOS) && !os(watchOS)
+                        .contextMenu {
+                            Button {
+                                LogEntryFormatter.copyToClipboard(entry.message)
+                            } label: {
+                                Label("Copy Message", systemImage: "doc.on.clipboard")
+                            }
+                            Button {
+                                LogEntryFormatter.copyToClipboard(
+                                    LogEntryFormatter.formatLine(entry)
+                                )
+                            } label: {
+                                Label("Copy Entry", systemImage: "list.clipboard")
+                            }
+                        }
+                        #endif
                     }
                     .listStyle(.plain)
                     .font(.system(.caption, design: .monospaced))
@@ -73,6 +94,12 @@ public struct LogPanelView: View {
             }
         }
         .frame(minWidth: 600, minHeight: 400)
+        .fileExporter(
+            isPresented: $isExporting,
+            document: exportDocument,
+            contentType: exportContentType,
+            defaultFilename: "logs"
+        ) { _ in }
         .onChange(of: timestampWidth) { _, value in
             UserDefaults.standard.set(value, forKey: "\(keyPrefix).logColumn.timestamp")
         }
@@ -137,6 +164,56 @@ public struct LogPanelView: View {
             Text("\(logStore.filteredEntries.count) entries")
                 .font(.caption)
                 .foregroundStyle(.secondary)
+
+            #if !os(tvOS) && !os(watchOS)
+            Divider()
+                .frame(height: 16)
+
+            Button {
+                let text = LogEntryFormatter.formatText(logStore.filteredEntries)
+                LogEntryFormatter.copyToClipboard(text)
+                copyBounce += 1
+            } label: {
+                Image(systemName: "doc.on.clipboard")
+                    .symbolEffect(.bounce, value: copyBounce)
+            }
+            .disabled(logStore.filteredEntries.isEmpty)
+            .help(logStore.filteredEntries.isEmpty
+                ? "No entries to copy"
+                : "Copy filtered entries to clipboard")
+            .accessibilityLabel("Copy all filtered entries to clipboard")
+            .keyboardShortcut("c", modifiers: [.command, .shift])
+
+            Menu {
+                Button("Export as Text...") {
+                    exportDocument = LogExportDocument(
+                        entries: logStore.filteredEntries, format: .plainText
+                    )
+                    exportContentType = .plainText
+                    isExporting = true
+                }
+                Button("Export as JSON...") {
+                    exportDocument = LogExportDocument(
+                        entries: logStore.filteredEntries, format: .json
+                    )
+                    exportContentType = .json
+                    isExporting = true
+                }
+            } label: {
+                Image(systemName: "square.and.arrow.up")
+            }
+            .disabled(logStore.filteredEntries.isEmpty)
+            #if os(macOS)
+            .menuStyle(.borderlessButton)
+            #endif
+            .help(logStore.filteredEntries.isEmpty
+                ? "No entries to export"
+                : "Export log entries")
+            .accessibilityLabel("Export log entries")
+
+            Divider()
+                .frame(height: 16)
+            #endif
 
             Toggle("Auto-scroll", isOn: $autoScroll)
                 #if os(macOS)

--- a/Tests/DevToolsKitLoggingTests/LogEntryFormattingTests.swift
+++ b/Tests/DevToolsKitLoggingTests/LogEntryFormattingTests.swift
@@ -1,0 +1,107 @@
+import DevToolsKit
+import Foundation
+import Testing
+
+@testable import DevToolsKitLogging
+
+@Suite(.serialized)
+@MainActor
+struct LogEntryFormattingTests {
+    private func makeEntry(
+        level: DevToolsLogLevel = .info,
+        source: String = "test",
+        message: String = "Hello",
+        metadata: String? = nil,
+        timestamp: Date = Date(timeIntervalSince1970: 1_710_244_245.123)
+    ) -> DevToolsLogEntry {
+        DevToolsLogEntry(
+            level: level, source: source, message: message,
+            metadata: metadata, timestamp: timestamp
+        )
+    }
+
+    @Test func formatLine_basicEntry() {
+        let entry = makeEntry()
+        let line = LogEntryFormatter.formatLine(entry)
+
+        #expect(line.contains("INF"))
+        #expect(line.contains("[test]"))
+        #expect(line.contains("Hello"))
+        #expect(!line.contains("\n"))
+    }
+
+    @Test func formatLine_withMetadata() {
+        let entry = makeEntry(metadata: "requestID=abc")
+        let line = LogEntryFormatter.formatLine(entry)
+
+        #expect(line.contains("Hello"))
+        #expect(line.contains("\n"))
+        #expect(line.contains("requestID=abc"))
+    }
+
+    @Test func formatLine_allLevels() {
+        let levels: [(DevToolsLogLevel, String)] = [
+            (.trace, "TRC"), (.debug, "DBG"), (.info, "INF"),
+            (.warning, "WRN"), (.error, "ERR"),
+        ]
+        for (level, code) in levels {
+            let line = LogEntryFormatter.formatLine(makeEntry(level: level))
+            #expect(line.contains(code))
+        }
+    }
+
+    @Test func formatText_multipleEntries() {
+        let entries = [
+            makeEntry(message: "First"),
+            makeEntry(message: "Second"),
+        ]
+        let text = LogEntryFormatter.formatText(entries)
+
+        #expect(text.contains("First"))
+        #expect(text.contains("Second"))
+        #expect(text.contains("\n"))
+    }
+
+    @Test func formatText_emptyArray() {
+        let text = LogEntryFormatter.formatText([])
+        #expect(text.isEmpty)
+    }
+
+    @Test func formatJSON_roundTrip() throws {
+        let entry = makeEntry(source: "network", message: "Request sent", metadata: "url=/api")
+        let json = try LogEntryFormatter.formatJSON([entry])
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode([DevToolsLogEntry].self, from: Data(json.utf8))
+
+        #expect(decoded.count == 1)
+        #expect(decoded[0].source == "network")
+        #expect(decoded[0].message == "Request sent")
+        #expect(decoded[0].metadata == "url=/api")
+        #expect(decoded[0].level == .info)
+    }
+
+    @Test func formatJSON_emptyArray() throws {
+        let json = try LogEntryFormatter.formatJSON([])
+        #expect(json == "[\n\n]")
+    }
+
+    @Test func codable_roundTrip() throws {
+        let entry = makeEntry(level: .warning, source: "db", message: "Slow query", metadata: "ms=500")
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(entry)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(DevToolsLogEntry.self, from: data)
+
+        #expect(decoded.id == entry.id)
+        #expect(decoded.level == entry.level)
+        #expect(decoded.source == entry.source)
+        #expect(decoded.message == entry.message)
+        #expect(decoded.metadata == entry.metadata)
+    }
+}

--- a/docs/logging/API.md
+++ b/docs/logging/API.md
@@ -33,8 +33,10 @@ public final class DevToolsLogStore: Sendable {
 
 ## DevToolsLogEntry
 
+> Since: 0.1.0 (Codable since 0.6.0)
+
 ```swift
-public struct DevToolsLogEntry: Identifiable, Sendable {
+public struct DevToolsLogEntry: Identifiable, Sendable, Codable {
     public let id: UUID
     public let timestamp: Date
     public let level: DevToolsLogLevel
@@ -76,3 +78,35 @@ public struct LogPanel: DevToolPanel {
 ```swift
 let exporter = DiagnosticExporter(manager: manager, logStore: logStore)
 ```
+
+## LogEntryFormatter
+
+> Since: 0.6.0
+
+```swift
+public enum LogEntryFormatter: Sendable {
+    public static func formatLine(_ entry: DevToolsLogEntry) -> String
+    public static func formatText(_ entries: [DevToolsLogEntry]) -> String
+    public static func formatJSON(_ entries: [DevToolsLogEntry]) throws -> String
+    @MainActor public static func copyToClipboard(_ text: String)  // macOS/iOS only
+}
+```
+
+Formats log entries as human-readable text (ISO 8601 timestamp, 3-letter level code, source, message) or pretty-printed JSON. `copyToClipboard(_:)` is unavailable on tvOS and watchOS.
+
+## LogExportDocument
+
+> Since: 0.6.0
+
+```swift
+public struct LogExportDocument: FileDocument {
+    public init(entries: [DevToolsLogEntry], format: LogExportFormat)
+}
+
+public enum LogExportFormat: Sendable {
+    case plainText
+    case json
+}
+```
+
+A `FileDocument` for use with SwiftUI's `.fileExporter()`. Wraps formatted log entries in either plain text or JSON format.

--- a/docs/logging/GUIDE.md
+++ b/docs/logging/GUIDE.md
@@ -70,9 +70,31 @@ logStore.append(DevToolsLogEntry(
 - **Level filter** — Segmented picker: All, Debug, Info, Warning, Error
 - **Source filter** — Dropdown of all known sources
 - **Search** — Full-text search across messages
+- **Copy All** — Copy all filtered entries to clipboard as text (⌘⇧C)
+- **Export** — Export filtered entries as plain text or JSON via file save dialog
 - **Auto-scroll** — Follows new entries in real time
 - **Entry count** — Badge showing filtered count
 - **Clear** — Remove all entries
+
+## Copy & Export (since 0.6.0)
+
+All copy and export operations respect active filters (level, source, search text). These features are available on macOS and iOS; they are hidden on tvOS and watchOS.
+
+### Toolbar
+
+The toolbar includes a **Copy All** button (`doc.on.clipboard` icon) that copies all filtered entries to the clipboard as formatted text. A bounce animation confirms the copy. Keyboard shortcut: **⌘⇧C**.
+
+The **Export** menu (`square.and.arrow.up` icon) offers two options:
+- **Export as Text...** — saves entries as a plain text file
+- **Export as JSON...** — saves entries as a pretty-printed JSON array
+
+Both use SwiftUI's `.fileExporter()` for a native save dialog.
+
+### Context Menu
+
+Right-click any log row for:
+- **Copy Message** — copies just the message text
+- **Copy Entry** — copies the full formatted line (timestamp, level, source, message, metadata)
 
 ## Filtering
 


### PR DESCRIPTION
## Summary

Closes #50

- **Copy All** toolbar button (⌘⇧C) copies all filtered log entries to clipboard as formatted text, with bounce animation feedback
- **Export menu** lets users save filtered entries as plain text or JSON via native file save dialog (`.fileExporter()`)
- **Context menu** on each log row: "Copy Message" (message only) and "Copy Entry" (full formatted line with timestamp, level, source, metadata)
- All operations respect active filters (level, source, search text)
- Copy/export buttons hidden on tvOS/watchOS where clipboard is unavailable

### New files
- `LogEntryFormatting.swift` — `LogEntryFormatter` enum with text/JSON formatting + clipboard helper
- `LogExportDocument.swift` — `FileDocument` for SwiftUI `.fileExporter()`
- `LogEntryFormattingTests.swift` — 8 tests covering formatting, Codable round-trips

### Modified files
- `DevToolsLogEntry.swift` — added `Codable` conformance
- `LogPanelView.swift` — toolbar buttons, file exporter, context menu
- `docs/logging/API.md` + `GUIDE.md` — documented new types and UI

## Test plan

- [x] `swift build` passes
- [x] `swift test --filter DevToolsKitLogging` — 30/30 tests pass (8 new)
- [ ] Manual: run demo app, generate logs, verify Copy All / Export / context menu
- [ ] Verify buttons disabled when no entries match filters
- [ ] Verify ⌘⇧C keyboard shortcut triggers Copy All

🤖 Generated with [Claude Code](https://claude.com/claude-code)