### PR TITLE
fix: prevent use-after-free crash when reopening DevTools window

### DIFF
--- a/Sources/DevToolsKit/Window/DevToolsTabbedWindow.swift
+++ b/Sources/DevToolsKit/Window/DevToolsTabbedWindow.swift
@@ -29,6 +29,7 @@ public final class DevToolsTabbedWindow {
             defer: false
         )
         window.title = "Developer Tools"
+        window.isReleasedWhenClosed = false
         window.contentView = NSHostingView(rootView: contentView)
         window.contentMinSize = CGSize(width: 500, height: 400)
         window.center()


### PR DESCRIPTION
## Summary

NSWindow deallocates itself when closed by default (isReleasedWhenClosed = true), but DevToolsTabbedWindow held a strong reference that became a dangling pointer. This caused an EXC_BAD_ACCESS crash (objc_retain) when the user reopened DevTools after closing it via the X button.

Setting isReleasedWhenClosed = false keeps the window alive while the reference exists, preventing the use-after-free.

## Changes

- Set `window.isReleasedWhenClosed = false` in DevToolsTabbedWindow initialization