### PR TITLE
fix: RetentionArchiver accepts value types — eliminate @Model escape at await boundaries

### DIFF
--- a/Sources/DevToolsKitMetricsStore/MetricsStoreActor.swift
+++ b/Sources/DevToolsKitMetricsStore/MetricsStoreActor.swift
@@ -333,9 +333,17 @@ public actor MetricsStoreActor {
             guard !batch.isEmpty else { break }
 
             if let archiver {
-                nonisolated(unsafe) let toArchive = batch
+                let snapshots = batch.map { obs in
+                    ArchivedObservation(
+                        timestamp: obs.timestamp,
+                        label: obs.label,
+                        typeRawValue: obs.typeRawValue,
+                        value: obs.value,
+                        dimensions: obs.dimensions.map { ($0.key, $0.value) }
+                    )
+                }
                 do {
-                    try await archiver.archive(observations: toArchive, reason: .sizeCap)
+                    try await archiver.archive(observations: snapshots, reason: .sizeCap)
                 } catch {
                     Self.logger.warning(
                         "RetentionArchiver failed during size-cap purge — deletion will proceed",
@@ -370,9 +378,17 @@ public actor MetricsStoreActor {
             let batch = (try? modelContext.fetch(descriptor)) ?? []
             guard !batch.isEmpty else { break }
 
-            nonisolated(unsafe) let toArchive = batch
+            let snapshots = batch.map { obs in
+                ArchivedObservation(
+                    timestamp: obs.timestamp,
+                    label: obs.label,
+                    typeRawValue: obs.typeRawValue,
+                    value: obs.value,
+                    dimensions: obs.dimensions.map { ($0.key, $0.value) }
+                )
+            }
             do {
-                try await archiver?.archive(observations: toArchive, reason: .ttl)
+                try await archiver?.archive(observations: snapshots, reason: .ttl)
             } catch {
                 Self.logger.warning(
                     "RetentionArchiver failed during TTL purge — deletion will proceed",

--- a/Sources/DevToolsKitMetricsStore/Retention/ArchivedObservation.swift
+++ b/Sources/DevToolsKitMetricsStore/Retention/ArchivedObservation.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Sendable value-type snapshot of a MetricObservation for archival.
+///
+/// Extracted on the actor before crossing async boundaries, eliminating
+/// the need to pass live `@Model` objects via `nonisolated(unsafe)`.
+///
+/// > Since: 0.12.0
+public struct ArchivedObservation: Sendable {
+    public let timestamp: Date
+    public let label: String
+    public let typeRawValue: String
+    public let value: Double
+    public let dimensions: [(key: String, value: String)]
+
+    public init(
+        timestamp: Date,
+        label: String,
+        typeRawValue: String,
+        value: Double,
+        dimensions: [(key: String, value: String)]
+    ) {
+        self.timestamp = timestamp
+        self.label = label
+        self.typeRawValue = typeRawValue
+        self.value = value
+        self.dimensions = dimensions
+    }
+}

--- a/Sources/DevToolsKitMetricsStore/Retention/RetentionArchiver.swift
+++ b/Sources/DevToolsKitMetricsStore/Retention/RetentionArchiver.swift
@@ -6,14 +6,18 @@ import Foundation
 /// Errors thrown by the archiver are logged at warning level and swallowed — they never
 /// block or abort the deletion that follows.
 ///
-/// > Since: 0.9.0
+/// Implementations receive ``ArchivedObservation`` value types rather than live `@Model`
+/// objects. Data is extracted synchronously on the actor before any `await`, so conforming
+/// types never need to touch `@Model` instances or a `ModelContext`.
+///
+/// > Since: 0.9.0 (updated to value types in 0.12.0)
 public protocol RetentionArchiver: Sendable {
     /// Called with a batch of observations that are about to be deleted.
     ///
     /// - Parameters:
-    ///   - observations: The batch of observations scheduled for deletion.
+    ///   - observations: Sendable snapshots of the observations scheduled for deletion.
     ///   - reason: Why the batch is being pruned (TTL expiry or size-cap enforcement).
-    func archive(observations: [MetricObservation], reason: RetentionPruneReason) async throws
+    func archive(observations: [ArchivedObservation], reason: RetentionPruneReason) async throws
 }
 
 /// The reason a batch of ``MetricObservation`` rows is being pruned.

--- a/Tests/DevToolsKitMetricsStoreTests/RetentionEngineArchiverTests.swift
+++ b/Tests/DevToolsKitMetricsStoreTests/RetentionEngineArchiverTests.swift
@@ -20,13 +20,12 @@ final class StubArchiver: Sendable, RetentionArchiver {
     nonisolated(unsafe) private var _calls: [ArchiveCall] = []
     nonisolated(unsafe) private var _shouldThrow: Bool = false
 
-    func archive(observations: [MetricObservation], reason: RetentionPruneReason) async throws {
+    func archive(observations: [ArchivedObservation], reason: RetentionPruneReason) async throws {
         // Use dispatch queue's sync method to safely access shared state from async context
         try queue.sync {
             if _shouldThrow {
                 throw TestError.archiveFailure
             }
-            // Store only the count and reason (observations are @Model objects, not Sendable)
             _calls.append(ArchiveCall(observationCount: observations.count, reason: reason))
         }
     }

--- a/Tests/DevToolsKitMetricsTests/MetricsManagerTests.swift
+++ b/Tests/DevToolsKitMetricsTests/MetricsManagerTests.swift
@@ -41,14 +41,14 @@ struct MetricsManagerTests {
         #expect(manager.totalEntries == 2)
     }
 
-    @Test func clearDelegatesToStorage() {
+    @Test func clearDelegatesToStorage() async {
         let store = InMemoryMetricsStorage()
         store.record(MetricEntry(label: "test", dimensions: [], type: .counter, value: 1))
 
         let manager = MetricsManager(storage: store)
         #expect(manager.totalEntries == 1)
 
-        manager.clear()
+        await manager.clear()
         #expect(manager.totalEntries == 0)
     }
 


### PR DESCRIPTION
## Summary

- **Breaking change**: `RetentionArchiver.archive(observations:reason:)` now accepts `[ArchivedObservation]` (Sendable value type) instead of `[MetricObservation]` (@Model)
- `MetricsStoreActor.maintenanceDeleteToFloor()` and `maintenancePurgeTTLObservations()` extract data synchronously on the actor before any `await`, eliminating both `nonisolated(unsafe)` escapes
- New `ArchivedObservation` struct carries exactly what archivers need: timestamp, label, typeRawValue, value, dimensions

## Context

Tenrec Terminal staging crashed on launch (metamech/Tenrec-Terminal#1470). The #1460 fix consolidated all SwiftData work onto one actor, but the `RetentionArchiver` protocol still accepted `@Model` objects. Callers were forced to use `nonisolated(unsafe)` to cross the boundary, and the `await` created a race window: `insert()` could mutate the `modelContext` while the archiver read `obs.dimensions` on a different thread.

This fix makes it impossible for any `RetentionArchiver` conformer to receive live `@Model` objects — the API boundary enforces value-type-only data transfer.

## Test plan

- [x] `swift build` passes
- [x] `swift test` passes
- [x] No `nonisolated(unsafe)` remains for @Model archiver escapes
- [ ] Tag `v0.12.1` after merge
- [ ] Update Tenrec-Terminal dependency to `v0.12.1`