### PR TITLE
polish: icon-only tabs, hide picker label, top-align empty states, async metrics load

### DIFF
--- a/Sources/DevToolsKit/Window/DevToolsDockView.swift
+++ b/Sources/DevToolsKit/Window/DevToolsDockView.swift
@@ -65,21 +65,18 @@ struct DevToolsDockView: View {
                     Button {
                         manager.activeDockPanelID = panel.id
                     } label: {
-                        HStack(spacing: 4) {
-                            Image(systemName: panel.icon)
-                                .font(.caption2)
-                            Text(panel.title)
-                                .font(.caption2)
-                        }
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 3)
-                        .background(
-                            manager.activeDockPanelID == panel.id
-                                ? Color.accentColor.opacity(0.15)
-                                : Color.clear,
-                            in: RoundedRectangle(cornerRadius: 4)
-                        )
+                        Image(systemName: panel.icon)
+                            .font(.caption)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 3)
+                            .background(
+                                manager.activeDockPanelID == panel.id
+                                    ? Color.accentColor.opacity(0.15)
+                                    : Color.clear,
+                                in: RoundedRectangle(cornerRadius: 4)
+                            )
                     }
+                    .help(panel.title)
                     .buttonStyle(.plain)
                     #if os(macOS)
                     .contextMenu {

--- a/Sources/DevToolsKit/Window/DevToolsTabbedWindow.swift
+++ b/Sources/DevToolsKit/Window/DevToolsTabbedWindow.swift
@@ -100,21 +100,18 @@ struct DevToolsTabbedContentView: View {
         Button {
             manager.activeTabbedPanelID = panel.id
         } label: {
-            HStack(spacing: 6) {
-                Image(systemName: panel.icon)
-                    .font(.caption)
-                Text(panel.title)
-                    .font(.caption)
-            }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 5)
-            .background(
-                manager.activeTabbedPanelID == panel.id
-                    ? Color.accentColor.opacity(0.15)
-                    : Color.clear,
-                in: RoundedRectangle(cornerRadius: 6)
-            )
+            Image(systemName: panel.icon)
+                .font(.body)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+                .background(
+                    manager.activeTabbedPanelID == panel.id
+                        ? Color.accentColor.opacity(0.15)
+                        : Color.clear,
+                    in: RoundedRectangle(cornerRadius: 6)
+                )
         }
+        .help(panel.title)
         .buttonStyle(.plain)
         #if os(macOS)
         .contextMenu {

--- a/Sources/DevToolsKitMetrics/Panels/MetricsPanel/MetricDetailView.swift
+++ b/Sources/DevToolsKitMetrics/Panels/MetricsPanel/MetricDetailView.swift
@@ -29,7 +29,8 @@ struct MetricDetailView: View {
                     systemImage: "chart.bar",
                     description: Text("No entries found for this metric.")
                 )
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding(.top, 40)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             }
         }
         .task(id: identifier) {

--- a/Sources/DevToolsKitMetrics/Panels/MetricsPanel/MetricsLiveView.swift
+++ b/Sources/DevToolsKitMetrics/Panels/MetricsPanel/MetricsLiveView.swift
@@ -66,7 +66,8 @@ struct MetricsLiveView: View {
                     systemImage: "chart.bar",
                     description: Text("Metrics will appear here when the app records data via swift-metrics.")
                 )
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding(.top, 40)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             } else {
                 List(selection: $selectedIdentifier) {
                     ForEach(displayedGroups, id: \.prefix) { group in
@@ -105,6 +106,12 @@ struct MetricsLiveView: View {
     }
 
     private func loadMetrics() async {
+        isLoading = true
+
+        // Yield so the view renders the ProgressView immediately before
+        // the synchronous data-fetch work blocks the main actor.
+        await Task.yield()
+
         let metrics = metricsManager.filteredMetrics
         let latestValues = metricsManager.latestValues
 

--- a/Sources/DevToolsKitMetrics/Panels/MetricsPanel/MetricsPanelView.swift
+++ b/Sources/DevToolsKitMetrics/Panels/MetricsPanel/MetricsPanelView.swift
@@ -41,6 +41,7 @@ public struct MetricsPanelView: View {
                     Text(tab.rawValue).tag(tab)
                 }
             }
+            .labelsHidden()
             .pickerStyle(.segmented)
             .frame(maxWidth: 200)
 

--- a/Sources/DevToolsKitMetrics/Panels/MetricsPanel/MetricsQueryView.swift
+++ b/Sources/DevToolsKitMetrics/Panels/MetricsPanel/MetricsQueryView.swift
@@ -67,7 +67,8 @@ struct MetricsQueryView: View {
                     systemImage: "magnifyingglass",
                     description: Text("Run a query to see matching metric entries.")
                 )
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding(.top, 40)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             } else {
                 Table(results) {
                     TableColumn("Time") { entry in

--- a/Sources/DevToolsKitMetrics/Panels/MetricsPanel/MetricsReportView.swift
+++ b/Sources/DevToolsKitMetrics/Panels/MetricsPanel/MetricsReportView.swift
@@ -12,7 +12,8 @@ struct MetricsReportView: View {
                     systemImage: "chart.bar.doc.horizontal",
                     description: Text("Metrics summaries will appear here once data is recorded.")
                 )
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding(.top, 40)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             } else {
                 Table(summaries) {
                     TableColumn("Label") { summary in


### PR DESCRIPTION
## Summary

- Tab buttons show icon only with `.help()` tooltip (tabbed window + dock)
- MetricsPanelView picker: add `.labelsHidden()` to suppress visible "Tab" label
- ContentUnavailableView: top-align with 40pt padding in all metrics panels
- MetricsLiveView: set `isLoading` + `Task.yield()` before sync data fetch so ProgressView renders immediately

Closes metamech/Tenrec-Terminal#1700