### PR TITLE
fix(#74): hide LicenseSeat module from DevToolsKitLicensingSeat swiftinterface

### DIFF
--- a/Sources/DevToolsKitLicensingSeat/LicenseSeatBackend.swift
+++ b/Sources/DevToolsKitLicensingSeat/LicenseSeatBackend.swift
@@ -1,6 +1,6 @@
 import DevToolsKitLicensing
 import Foundation
-import LicenseSeat
+internal import LicenseSeat
 
 /// License backend for website-distributed apps using LicenseSeat + LemonSqueezy.
 ///
@@ -59,7 +59,7 @@ public final class LicenseSeatBackend: LicenseBackend, @unchecked Sendable {
 
     public func validate() async throws {
         guard let license = seat.currentLicense() else {
-            throw LicenseSeatStoreError.notConfigured
+            throw LicenseSeatBackendError.notConfigured
         }
         _ = try await seat.validate(licenseKey: license.licenseKey)
         syncStatus()
@@ -105,4 +105,12 @@ public final class LicenseSeatBackend: LicenseBackend, @unchecked Sendable {
         }
         return entitlements
     }
+}
+
+/// Errors thrown by ``LicenseSeatBackend``.
+///
+/// Declared locally so the backing LicenseSeat module does not appear in the
+/// public import surface of `DevToolsKitLicensingSeat`.
+enum LicenseSeatBackendError: Error {
+    case notConfigured
 }


### PR DESCRIPTION
## Summary

Swift 6 `internal import LicenseSeat` in `Sources/DevToolsKitLicensingSeat/LicenseSeatBackend.swift` so the module's compiled `.swiftmodule` / `.swiftinterface` no longer advertises `LicenseSeat` as a consumer-visible dependency. Single source-level reference to `LicenseSeatStoreError` replaced with a local `LicenseSeatBackendError` so the `internal import` compiles.

Completes #74: PR #75 bundled LicenseSeat object files (linker symbols) but consumers still failed with `error: unable to resolve module dependency: 'LicenseSeat'` because the swiftmodule interface still listed it. After this change, consumers (e.g. Tenrec-Terminal#1737) do not need `LicenseSeat.swiftmodule` on the module search path.

## Verification

- [x] `swift build` passes.
- [x] `swift test --filter DevToolsKitLicensing` + `--filter Seat` pass.
- [x] `make frameworks-licensingseat` produces a valid `DevToolsKitLicensingSeat.xcframework`.
- [x] Resulting `arm64-apple-macos.swiftinterface` import list no longer contains `import LicenseSeat` (public and private interfaces both clean).
- [ ] Tenrec-Terminal#1737 build passes against v0.14.1 — validated by consumer after merge+tag.

## Release plan

- Tag `v0.14.1` immediately after merge.
- Release notes call this out as the consumer-visible completion of #74.